### PR TITLE
Move the design documents into the Raku era

### DIFF
--- a/S01-overview.pod
+++ b/S01-overview.pod
@@ -15,14 +15,14 @@ Synopsis 1: Overview
 This document originally summarized Apocalypse 1, which covers the
 initial design concept.  That original summary may be found below
 under "Random Thoughts".  However, these Synopses also contain
-updates to reflect the evolving design of Perl 6 over time, unlike
+updates to reflect the evolving design of Raku over time, unlike
 the Apocalypses, which are frozen in time as "historical documents".
 These updates are not marked--if a Synopsis disagrees with its
 Apocalypse, assume the Synopsis is correct.
 
 Another assumption has been that if we don't talk about something in these
-Synopses, it's the same as it is in Perl 5.  Soon we plan to fill in
-the gaps with the Perl 5 details though.
+Synopses, it's the same as it is in Perl.  Soon we plan to fill in
+the gaps with the Perl details though.
 
 =head1 Project Plan
 
@@ -33,18 +33,18 @@ primarily a volunteer effort.
 
 This document does not attempt to summarize all these subprojects--see
 L<http://perl6.org> for such information.  What we can say here
-is that, unlike how it was with Perl 5, none of these projects is
-designed to be the Official Perl.  Perl 6 is anything that passes the
+is that, unlike how it was with Perl, none of these projects is
+designed to be the Official Raku.  Raku is anything that passes the
 official test suite.  This test suite was initially developed under the
 Pugs project because that project was at one point the furthest along
-in exploring the high-level semantics of Perl 6.  (Other projects
+in exploring the high-level semantics of Raku.  (Other projects
 may be better at other things, such as speed or interoperability.
 This is fine; it is not necessary that all implementations be equally
 good at everything.)  The official test suite is community property,
-and is intended to be platform neutral, so that Perl 6 is defined
+and is intended to be platform neutral, so that Raku is defined
 primarily by its desired semantics, not by accidents of history.
 
-Another aspect of this is the Perl 6 compiler will be self-hosting.
+Another aspect of this is the Raku compiler will be self-hosting.
 That is, the compiler will eventually compile itself, at least down
 to the point where various code-generating backends can take over.
 This largely removes platform dependencies from the frontend, so that
@@ -77,7 +77,7 @@ Larry's First Law of Language Redesign: Everyone wants the colon.
 
 RFCs are rated on "PSA": whether they point out a real B<P>roblem,
 whether they present a viable B<S>olution, and whether that solution is
-likely to be B<A>ccepted as part of Perl 6.
+likely to be B<A>ccepted as part of Raku.
 
 =item *
 
@@ -86,21 +86,21 @@ present the language to a new user.
 
 =item *
 
-Perl 6 should be malleable enough that it can evolve into the imaginary
-perfect language, Perl 7.  This darwinian imperative implies support
+Raku should be malleable enough that it can evolve into an imaginary
+perfect language with another name.  This darwinian imperative implies support
 for multiple syntaxes above and multiple platforms below.
 
 =item *
 
 Many details may change, but the essence of Perl will remain unchanged.
-Perl will continue to be a multiparadigmatic, context-sensitive
+Raku will continue to be a multiparadigmatic, context-sensitive
 language.  We are not turning Perl into any other existing language.
 
 =item *
 
-Migration is important.  A Perl 6 interpreter, if invoked as "C<perl>", will assume that it
-is being fed Perl 5 code unless the code starts with a "class" or
-"module" keyword, or you specifically tell it you're running Perl 6
+Migration is important.  A Raku interpreter, if invoked as "C<raku>", will assume that it
+is being fed Perl code unless the code starts with a "class" or
+"module" keyword, or you specifically tell it you're running Raku
 code in some other way, such as by:
 
     #!/usr/bin/perl6
@@ -109,38 +109,38 @@ code in some other way, such as by:
 Also, a file with a C<.p6> extension may be taken as indicative,
 as may any other extension containing the digit C<6>, such as C<p6l>
 or C<p6m> or C<pl6> or C<pm6>.  (Though C<.pl> and C<.pm> are still
-perfectly acceptable extensions as long as the Perl-6-ness is indicated
+perfectly acceptable extensions as long as the Raku-ness is indicated
 by one of the other indicators.)
 
 =item *
 
-Migration in the other direction is also important.  In Perl 6
-mode, one can drop back to Perl 5 mode  with C<use v5> at the
+Migration in the other direction is also important.  In Raku
+mode, one can drop back to Perl mode  with C<use v5> at the
 beginning of a lexical block.  Such blocks may be nested:
 
     use v6;
-    # ...some Perl 6 code...
+    # ...some Raku code...
     {
         use v5;
-        # ...some Perl 5 code...
+        # ...some Perl code...
         {
             use v6;
-            # ...more Perl 6 code...
+            # ...more Raku code...
         }
     }
 
-Some platforms may restrict this to a subset of Perl 5 when it is
-not expedient to include a full Perl 5 interpreter.  The standard
-Perl 6 grammar will include the ability to parse a well-behaved
-subset of Perl 5 on its own (much like PPI does); implementations
+Some platforms may restrict this to a subset of Perl when it is
+not expedient to include a full Perl interpreter.  The standard
+Raku grammar will include the ability to parse a well-behaved
+subset of Perl on its own (much like PPI does); implementations
 are required only to support this subset, though of course they may
 also choose to implement bug-for-bug compatibility.
 
 =item *
 
-Scaling is one of those areas where Perl needs to be multiparadigmatic
-and context sensitive.  Perl 5 code is not strict by default, while
-Perl 6 code is.   But it should be easy to relax with C<-e> or the
+Scaling is one of those areas where Raku needs to be multiparadigmatic
+and context sensitive.  Perl code is not strict by default, while
+Raku code is.   But it should be easy to relax with C<-e> or the
 'no strict' pragma:
 
     perl -e '$x = 1'
@@ -156,8 +156,8 @@ modules on the user's behalf.
 
 =item *
 
-If you want to treat everything as objects in Perl 6, Perl will help
-you do that.  If you don't want to treat everything as objects, Perl
+If you want to treat everything as objects in Raku, Raku will help
+you do that.  If you don't want to treat everything as objects, Raku
 will help you with that viewpoint as well.
 
 =item *
@@ -176,7 +176,7 @@ will be, despite requests for those particular features.  Therefore
 the design process will be spiral, cooperative, and convergent.
 The rate of convergence is an emergent property, and cannot be forced,
 only encouraged.  As long as anyone is hacking on any implementation
-of Perl 6 to make it conform to the test suite, or hacking on the
+of Raku to make it conform to the test suite, or hacking on the
 test suite to make it reflect consensus of specification, the rate
 of convergence will be deemed to be positive.  If you are unhappy
 with the current rate of convergence, please cooperate more with
@@ -197,7 +197,7 @@ should be considered somewhat conjectural, even if not so marked.
 As implementations start to agree on what is practical and what is not,
 do not be surprised if some features that are currently specced may be
 deferred to future versions; these should still be considered long-term
-direction in the evolution of Perl 6 over time, and the short-term
+direction in the evolution of Raku over time, and the short-term
 design should be conservative in preserving that long-term evolution.
 Note that we are not in a hurry to defer any sections of the spec,
 even if that would give the illusion of progress.  Convergence

--- a/S02-bits.pod
+++ b/S02-bits.pod
@@ -13,14 +13,14 @@ Synopsis 2: Bits and Pieces
 
 This document summarizes Apocalypse 2, which covers small-scale lexical
 items and typological issues.  (These Synopses also contain updates to
-reflect the evolving design of Perl 6 over time, unlike the Apocalypses,
+reflect the evolving design of Raku over time, unlike the Apocalypses,
 which are frozen in time as "historical documents".  These updates are not
 marked--if a Synopsis disagrees with its Apocalypse, assume the Synopsis is
 correct.)
 
 =head1 One-pass parsing
 
-To the extent allowed by sublanguages' parsers, Perl is parsed using a
+To the extent allowed by sublanguages' parsers, Raku is parsed using a
 one-pass, predictive parser.  That is, lookahead of more than one "longest
 token" is discouraged.  The currently known exceptions to this are where the
 parser must:
@@ -44,31 +44,31 @@ dealing with at any moment, which in turn is fundamental to allowing
 unambiguous language mutation in any desired direction.  (Generic languages
 are allowed, but only if intended; accidentally generic languages lead to
 loss of linguistic identity and integrity.  This is the hard lesson of
-Perl 5's source filters and other multi-pass parsing mistakes.)
+Perl's source filters and other multi-pass parsing mistakes.)
 
 =head1 Lexical Conventions
 
 =head2 Unicode Semantics
 
-In the abstract, Perl is written in Unicode, and has consistent Unicode
+In the abstract, Raku is written in Unicode, and has consistent Unicode
 semantics regardless of the underlying text representations.  By default
-Perl presents Unicode in "NFG" formation, where each grapheme counts as one
+Raku presents Unicode in "NFG" formation, where each grapheme counts as one
 character.  A grapheme is what the novice user would think of as a character
 in their normal everyday life, including any diacritics.
 
-Perl can count Unicode line and paragraph separators as line markers, but
-that behavior had better be configurable so that Perl's idea of line numbers
+Raku can count Unicode line and paragraph separators as line markers, but
+that behavior had better be configurable so that Raku's idea of line numbers
 matches what your editor thinks about Unicode lines.
 
 Unicode horizontal whitespace is counted as whitespace, but it's better not
 to use thin spaces where they will make adjoining tokens look like a single
-token.  On the other hand, Perl doesn't use indentation as syntax, so you
+token.  On the other hand, Raku doesn't use indentation as syntax, so you
 are free to use any amount of whitespace anywhere that whitespace makes
 sense. Comments always count as whitespace.
 
 =head2 Bracketing Characters
 
-For some syntactic purposes, Perl distinguishes bracketing characters from
+For some syntactic purposes, Raku distinguishes bracketing characters from
 non-bracketing.  Bracketing characters are defined as any Unicode characters
 with either bidirectional mirrorings or Ps/Pe/Pi/Pf properties.
 
@@ -90,7 +90,7 @@ C<U+2990> (C<⦐>) are valid bracket openers, despite having reverse mappings in
 BidiMirroring table.
 
 The C<U+301D> (C<〝>) codepoint has two closing alternatives, C<U+301E> (C<〞>) and
-C<U+301F> (C<〟>); Perl 6 only recognizes the one with lower code point number,
+C<U+301F> (C<〟>); Raku only recognizes the one with lower code point number,
 C<U+301E> (C<〞>), as the closing brace.  This policy also applies to new
 one-to-many mappings introduced in the future.
 
@@ -103,8 +103,8 @@ alternatives are treated as non-bracketing characters within that construct.
 
 =head2 Multiline Comments
 
-Pod sections may be used reliably as multiline comments in Perl 6.  Unlike
-in Perl 5, Pod syntax now lets you use C<=begin comment> and C<=end comment>
+Pod sections may be used reliably as multiline comments in Raku.  Unlike
+in Perl, Pod syntax now lets you use C<=begin comment> and C<=end comment>
 to delimit a Pod block correctly without the need for C<=cut>.  (In fact,
 C<=cut> is now gone.)  The format name does not have to be C<comment> -- any
 unrecognized format name will do to make it a comment.  (However, bare
@@ -123,14 +123,14 @@ documentation.
 =head2 Single-line Comments
 
 Except within a quote literal, a C<#> character always introduces a comment
-in Perl 6.  There are two forms of comment based on C<#>.  Embedded comments
+in Raku.  There are two forms of comment based on C<#>.  Embedded comments
 require the C<#> to be followed by a backtick (C<`>) plus one or more
 opening bracketing characters.
 
 All other uses of C<#> are interpreted as single-line comments that work
-just as in Perl 5, starting with a C<#> character and ending at the
+just as in Perl, starting with a C<#> character and ending at the
 subsequent newline.  They count as whitespace equivalent to newline for
-purposes of separation.  Unlike in Perl 5, C<#> may I<not> be used as the
+purposes of separation.  Unlike in Perl, C<#> may I<not> be used as the
 delimiter in quoting constructs.
 
 =head2 Embedded Comments
@@ -187,11 +187,11 @@ C<m>, C<s>, C<tr>, and C<rx>) enable subsequent user-selected brackets.
 
 Some languages such as C allow you to escape newline characters to combine
 lines.  Other languages (such as regexes) allow you to backslash a space
-character for various reasons.  Perl 6 generalizes this notion to any kind
+character for various reasons.  Raku generalizes this notion to any kind
 of whitespace.  Any contiguous whitespace (including comments) may be hidden
 from the parser by prefixing it with C<\>.  This is known as the "unspace".
-An unspace can suppress any of several whitespace dependencies in Perl.  For
-example, since Perl requires an absence of whitespace between a noun and a
+An unspace can suppress any of several whitespace dependencies in Raku.  For
+example, since Raku requires an absence of whitespace between a noun and a
 postfix operator, using unspace lets you line up postfix operators:
 
     %hash\  {$key}
@@ -303,16 +303,16 @@ restriction on unspace applies only at the normal pattern-matching level.)
 
 =head2 Optional Whitespace and Exclusions
 
-In general, whitespace is optional in Perl 6 except where it is needed to
+In general, whitespace is optional in Raku except where it is needed to
 separate constructs that would be misconstrued as a single token or other
-syntactic unit.  (In other words, Perl 6 follows the standard
+syntactic unit.  (In other words, Raku follows the standard
 I<longest-token> principle, or in the cases of large constructs, a I<prefer
 shifting to reducing> principle.  See L</Grammatical Categories> below for
-more on how a Perl program is analyzed into tokens.)
+more on how a Raku is analyzed into tokens.)
 
 This is an unchanging deep rule, but the surface ramifications of it change
 as various operators and macros are added to or removed from the language,
-which we expect to happen because Perl 6 is designed to be a mutable
+which we expect to happen because Raku is designed to be a mutable
 language.  In particular, there is a natural conflict between postfix
 operators and infix operators, either of which may occur after a term.  If a
 given token may be interpreted as either a postfix operator or an infix
@@ -430,14 +430,14 @@ you omit the definition, you'd get a message like this:
 
 =head1 Built-In Data Types
 
-Perl 6 has an optional type system that helps you write safer code that
+Raku has an optional type system that helps you write safer code that
 performs better.  The compiler is free to infer what type information it can
 from the types you supply, but it will not complain about missing type
 information unless you ask it to.
 
-Perl 6 is an OO engine, but you're not generally required to think in OO
+Raku is an OO engine, but you're not generally required to think in OO
 when that's inconvenient.  However, some built-in concepts such as
-filehandles are more object-oriented in a user-visible way than in Perl 5.
+filehandles are more object-oriented in a user-visible way than in Perl.
 
 =head2 The P6opaque Datatype
 
@@ -467,7 +467,7 @@ immutable.
 
 =head2 Properties on Objects
 
-Perl 6 supports the notion of B<properties> on various kinds of objects.
+Raku supports the notion of B<properties> on various kinds of objects.
 Properties are like object attributes, except that they're managed by the
 individual object rather than by the object's class.
 
@@ -619,7 +619,7 @@ If you say
 you are declaring that the elements of C<@array> are native integers, but
 that the array itself is implemented by the C<MyArray> class.  Untyped
 arrays and hashes are still perfectly acceptable, but have the same
-performance issues they have in Perl 5.
+performance issues they have in Perl.
 
 =head2 Methods on Arrays
 
@@ -646,7 +646,7 @@ Non-object (native) types are lowercase: C<int>, C<num>, C<complex>, C<rat>,
 C<buf>, C<bit>.  Native types are primarily intended for declaring compact
 array storage, that is, a sequence of storage locations of the specified
 type laid out in memory contiguously without pointer indirection.  However,
-Perl will try to make those look like their corresponding uppercase types if
+Raku will try to make those look like their corresponding uppercase types if
 you treat them that way. (In other words, it does autoboxing and
 autounboxing as necessary.  Note, however, that repeated autoboxing and
 unboxing can make your program much slower, compared to a program that makes
@@ -737,7 +737,7 @@ merely managed by the same meta object.)
 
 =head2 Roles
 
-Perl supports generic types through what are called "roles" which represent
+Raku supports generic types through what are called "roles" which represent
 capabilities or interfaces.  These roles are generally not used directly as
 object types.  For instance all the numeric types perform the C<Numeric>
 role, and all string types perform the C<Stringy> role, but there's no such
@@ -758,7 +758,7 @@ roles include:
 
 =head2 C<Numeric> Types
 
-Perl 6 intrinsically supports big integers and rationals through its system
+Raku intrinsically supports big integers and rationals through its system
 of type declarations.  C<Int> automatically supports promotion to arbitrary
 precision, as well as holding C<Inf> and C<NaN> values.  Note that C<Int>
 assumes 2's complement arithmetic, so C<+^1 == -2> is guaranteed.  (Native
@@ -854,7 +854,7 @@ promotion of reasonably fast C<Rat> values into arbitrarily slow C<FatRat>
 values.
 
 Although most rational implementations normalize or "reduce" fractions to
-their smallest representation immediately through a GCD algorithm, Perl
+their smallest representation immediately through a GCD algorithm, Raku
 allows a rational datatype to do so lazily at need, such as whenever the
 denominator would run out of precision, but avoid the overhead otherwise.
 Hence, if you are adding a bunch of C<Rat>s that represent, say, dollars and
@@ -894,7 +894,7 @@ include the C<e> for the exponential.
 
 =head2 Infinity and C<NaN>
 
-Perl 6 by default makes standard IEEE floating point concepts visible, such
+Raku by default makes standard IEEE floating point concepts visible, such
 as C<Inf> (infinity) and C<NaN> (not a number).  Within a lexical scope,
 pragmas may specify the nature of temporary values, and how floating point
 is to behave under various circumstances.  All IEEE modes must be lexically
@@ -903,7 +903,7 @@ to bypass a braindead platform.
 
 The default floating-point modes do not throw exceptions but rather
 propagate C<Inf> and C<NaN>.  The boxed object types may carry more detailed
-information on where overflow or underflow occurred.  Numerics in Perl are
+information on where overflow or underflow occurred.  Numerics in Raku are
 not designed to give the identical answer everywhere.  They are designed to
 give the typical programmer the tools to achieve a good enough answer most
 of the time.  (Really good programmers may occasionally do even better.)
@@ -922,7 +922,7 @@ memory is implementation defined, so implementations are free to use ropes
 or other data structures internally in order to make concatenation, substring,
 and so forth cheaper.
 
-Implementation note: since Perl 6 mandates that C<Str> must view graphemes
+Implementation note: since Raku mandates that C<Str> must view graphemes
 as the fundamental unit rather than codepoints, this has some implications
 regarding efficient implementation. It is suggested that all graphemes be
 translated on input to unique grapheme numbers and represented as integers
@@ -1029,7 +1029,7 @@ special meaning:
     @slice = %x{*;'foo'};               # all keys in domain of 1st dimension
     @array[*]                           # list of all values, unlike @array[]
     (*, *, $x) = (1, 2, 3);             # skip first two elements
-                                        # (same as lvalue "undef" in Perl 5)
+                                        # (same as lvalue "undef" in Perl)
 
 C<Whatever> is an undefined prototype object derived from C<Any>.  As a type
 it is abstract, and may not be instantiated as a defined object.  When used
@@ -1048,7 +1048,7 @@ C<:-)>]
 
 =head3 Autopriming of Unary and Binary Operators with Whatever
 
-Perl 6 has several ways of performing partial function application.  Since
+Raku has several ways of performing partial function application.  Since
 this is an unwieldy term, we've settled on calling it I<priming>.  (Many
 folks call this "currying", but that's not really a correct technical usage
 of the term.)  Most generally, priming is performed on a C<Callable> object
@@ -1276,7 +1276,7 @@ treat them as objects:
     complex     native complex number
     bool        native boolean
 
-Since native types cannot represent Perl's concept of undefined values, in
+Since native types cannot represent Raku's concept of undefined values, in
 the absence of explicit initialization, native floating-point types default
 to C<NaN>, while integer types (including C<bit>) default to 0.  The complex
 type defaults to C<NaN + NaN\i>.  A buf type of known size defaults to a
@@ -1311,7 +1311,7 @@ based on 32-bit integers produces valid UTF-32 in the native endianness.)
 
 Among other things, C<Mu> is named after the eastern concept of "Mu" or 無
 (see L<http://en.wikipedia.org/wiki/MU>, especially the "Mu (negative)"
-entry), so in Perl 6 it stands in for Perl 5's concept of "undef" when that
+entry), so in Raku it stands in for Perl's concept of "undef" when that
 is used as a noun.  However, C<Mu> is also the "nothing" from which
 everything else is derived via the undefined type objects, so it stands in
 for the concept of "Object" as used in languages like Java.  Or think of it
@@ -1332,7 +1332,7 @@ everything and nothing.
 
 =head2 Undefined types
 
-Perl 6 does not have a single value representing undefinedness.  Instead,
+Raku does not have a single value representing undefinedness.  Instead,
 objects of various types can carry type information while nevertheless
 remaining undefined themselves.  Whether an object is defined is determined
 by whether C<.defined> returns true or not.  These typed objects typically
@@ -1348,9 +1348,9 @@ Whenever you declare any kind of type, class, module, or package, you're
 automatically declaring an undefined prototype value with the same name,
 known as the I<type object>.  The name itself returns that type object:
 
-    Mu          Perl 6 object (default block parameter type, Any, Junction, or Each)
-    Any         Perl 6 object (default routine parameter type, excludes Junction, Nil, Failure)
-    Cool        Perl 6 Convenient OO Loopbacks
+    Mu          Raku object (default block parameter type, Any, Junction, or Each)
+    Any         Raku object (default routine parameter type, excludes Junction, Nil, Failure)
+    Cool        Raku Convenient OO Loopbacks
     Whatever    Wildcard (like Any, but subject to do-what-I-mean via MMD)
     Int         Any Int object
     Widget      Any Widget object
@@ -1366,7 +1366,7 @@ name classes when the type's associated meta-object allows it:
 The C<Any> type encompasses all normal value and object types.  It is the
 unit type, but includes units that are containers of multiple values.  It is
 not the most general type, however.  C<Any> derives from C<Mu>, which is the
-top type in Perl 6, and encompasses certain conceptual types that fall
+top type in Raku, and encompasses certain conceptual types that fall
 outside the realm of ordinary C<Any> values.  These conceptual types
 include:
 
@@ -1384,7 +1384,7 @@ I<autothreading>.
 
 The C<Failure> type is considered conceptual so that dynamic context can
 determine the treatment of failures that in other languages would always
-throw exceptions.  This gives Perl 6 programs the flexibility to handle
+throw exceptions.  This gives Raku programs the flexibility to handle
 exceptions either in-band or out-of-band.  It is particularly important to
 be able to handle exceptions in-band when you are trying to perform parallel
 operations, so that the failure of one computation does not result in
@@ -1416,15 +1416,15 @@ Objects with these types behave like values, i.e. C<$x === $y> is true if
 and only if their types and contents are identical (that is, if C<$x.WHICH>
 eqv C<$y.WHICH>).
 
-    Str         Perl string (finite sequence of Unicode characters)
-    Bit         Perl single bit (allows traits, aliasing, undefinedness, etc.)
-    Int         Perl integer (allows Inf/NaN, arbitrary precision, etc.)
-    Num         Perl number (approximate Real, generally via floating point)
-    Rat         Perl rational (exact Real, limited denominator)
-    FatRat      Perl rational (unlimited precision in both parts)
-    Complex     Perl complex number
-    Bool        Perl boolean
-    Exception   Perl exception
+    Str         Raku string (finite sequence of Unicode characters)
+    Bit         Raku single bit (allows traits, aliasing, undefinedness, etc.)
+    Int         Raku integer (allows Inf/NaN, arbitrary precision, etc.)
+    Num         Raku number (approximate Real, generally via floating point)
+    Rat         Raku rational (exact Real, limited denominator)
+    FatRat      Raku rational (unlimited precision in both parts)
+    Complex     Raku complex number
+    Bool        Raku boolean
+    Exception   Raku exception
     Block       Executable objects that have lexical scopes
     Range       A pair of Ordered endpoints
     Set         Unordered collection of values that allows no duplicates
@@ -1607,24 +1607,24 @@ Objects with these types have distinct C<.WHICH> values that do not change
 even if the object's contents change.  (Routines are considered mutable
 because they can be wrapped in place.)
 
-    Iterator    Perl list
+    Iterator    Raku list
     RangeIter   Iterator over a Range
-    Scalar      Perl scalar
-    Array       Perl array
-    Hash        Perl hash
+    Scalar      Raku scalar
+    Array       Raku array
+    Hash        Raku hash
     SetHash     Setty QuantHash[Bool,False]
     BagHash     Baggy QuantHash[UInt,0]
     MixHash     Mixy  QuantHash[Real,0.0]
     Pair        A single key-to-value association
-    Buf         Perl buffer (array of integers with some stringy features)
-    IO          Perl filehandle
+    Buf         Raku buffer (array of integers with some stringy features)
+    IO          Raku filehandle
     Routine     Base class for all wrappable executable objects
-    Sub         Perl subroutine
-    Method      Perl method
-    Submethod   Perl subroutine acting like a method
-    Macro       Perl compile-time subroutine
-    Regex       Perl pattern
-    Match       Perl match, usually produced by applying a pattern
+    Sub         Raku subroutine
+    Method      Raku method
+    Submethod   Raku subroutine acting like a method
+    Macro       Raku compile-time subroutine
+    Regex       Raku pattern
+    Match       Raku match, usually produced by applying a pattern
     Stash       A symbol table hash (package, module, class, lexpad, etc)
     SoftRoutine A routine that is committed to staying mutable
 
@@ -1701,7 +1701,7 @@ See L<S06/"Wrapping"> for a discussion of soft vs. hard routines.
 
 =head2 Of types
 
-Explicit types are optional. Perl variables have two associated types: their
+Explicit types are optional. Raku variables have two associated types: their
 "of type" and their "container type".  (More generally, any container has a
 container type, including subroutines and modules.) The C<of> type is stored
 as its C<of> property, while the container type of the container is just the
@@ -1749,8 +1749,8 @@ given as a trait of the variable:
     my $spot is PersistentScalar;
     my $spot is DataBase;
 
-Defining a container type is the Perl 6 equivalent to tying a variable in
-Perl 5.  But Perl 6 variables are tied directly at declaration time, and for
+Defining a container type is the Raku equivalent to tying a variable in
+Perl.  But Raku variables are tied directly at declaration time, and for
 performance reasons may not be tied with a run-time C<tie> statement unless
 the variable is explicitly declared with a container type that does the
 C<Tieable> role.
@@ -1862,7 +1862,7 @@ followed by a character matching C<< <.alpha> >>)
 
 =head2 Sigils
 
-Perl 6 includes a system of B<sigils> to mark the fundamental structural
+Raku includes a system of B<sigils> to mark the fundamental structural
 type of a variable:
 
     $   scalar (object)
@@ -1934,7 +1934,7 @@ list does not imply subscripting back into the original object.
 
 =head3 No intervening whitespace
 
-Unlike in Perl 5, you may no longer put whitespace between a sigil and its
+Unlike in Perl, you may no longer put whitespace between a sigil and its
 following name or construct.
 
 =head2 Twigils
@@ -2007,27 +2007,27 @@ container.
 
 =head2 The C<.perl> method
 
-To get a Perlish representation of any object, use the C<.perl> method.
-Like the C<Data::Dumper> module in Perl 5, the C<.perl> method will put
+To get a Rakuish representation of any object, use the C<.raku> method.
+Like the C<Data::Dumper> module in Perl, the C<.raku> method will put
 quotes around strings, square brackets around list values, curlies around
 hash values, constructors around objects, properly handle circular
-references etc., so that Perl can evaluate the result back to the same
-object.  The C<.perl> method will return a representation of the object on
+references etc., so that Raku can evaluate the result back to the same
+object.  The C<.raku> method will return a representation of the object on
 the assumption that, if the code is reparsed at some point, it will be used
 to regenerate the object as a scalar in item context.  If you wish to
 interpolate the regenerated object in a list context, it may be necessary to
 use C<< prefix:<|> >> to force interpolation.
 
-Note that C<.perl> has a very specific definition, and it is expected that
+Note that C<.raku> has a very specific definition, and it is expected that
 some modules will rely on the ability to roundtrip values with C<EVAL>.  As
 such, overriding C<.perl> with a different format (globally using
 C<MONKEY-TYPING>, or for specific classes unless special care is taken to
-maintain parsability) is unwise.  Code which does not depend on C<.perl>'s
+maintain parsability) is unwise.  Code which does not depend on C<.raku>'s
 definition should use C<.gist> instead to allow more control.
 
 =head2 The C<.gist> method
 
-C<.gist>, by contrast with C<.perl>, returns a flexible form of an object
+C<.gist>, by contrast with C<.raku>, returns a flexible form of an object
 intended for human interpretation.  For example, when presented with a very
 long list or array, only the first 100 entries will be printed, followed by
 C<...> to indicate there are more entries.  If that's not what you want,
@@ -2127,7 +2127,7 @@ with a single dollar sign:
 =head2 List assignment and binding
 
 There is a need to distinguish list assignment from list binding.  List
-assignment works much like it does in Perl 5, copying the values.  There's a
+assignment works much like it does in Perl, copying the values.  There's a
 new C<:=> binding operator that lets you bind names to C<Array> and C<Hash>
 objects without copying, in the same way as subroutine arguments are bound
 to formal parameters.  See S06 for more about binding.
@@ -2262,10 +2262,10 @@ Str($/) )> to operate on the current match object; similarly C<@()> and
 C<%()> can extract positional and named submatches.
 
 C<Capture> objects fill the ecological niche of references in
-Perl 6.  You can think of them as "fat" references, that is, references that
+Raku.  You can think of them as "fat" references, that is, references that
 can capture not only the current identity of a single object, but also the
 relative identities of several related objects.  Conversely, you can think
-of Perl 5 references as a degenerate form of C<Capture> when you want to
+of Perl references as a degenerate form of C<Capture> when you want to
 refer only to a single item.
 
 The C<sink> statement prefix will eagerly evaluate any block or statement,
@@ -2287,7 +2287,7 @@ returning an empty list:
         $_ + 1;
     } or sink { warn 'Nil result'; $warnings++; }
 
-Given C<sink>, there's no need for an "else" clause on Perl 6's loops, and
+Given C<sink>, there's no need for an "else" clause on Raku's loops, and
 the C<sink> construct works in any list, not just C<for> loops.
 
 =head2 CaptureCursors
@@ -2326,7 +2326,7 @@ names yourself via an additional signature in parentheses:
 
 =head2 Ampersand and invocation
 
-Unlike in Perl 5, the notation C<&foo> merely stands for the C<foo> function
+Unlike in Perl, the notation C<&foo> merely stands for the C<foo> function
 as a C<Routine> object without calling it.  You may call any Code object by
 dereferencing it with parens (which may, of course, contain arguments):
 
@@ -2411,7 +2411,7 @@ A consequence of this is that you may not put more than one statement inside
 parens or brackets expecting sequence semantics, that is, the way a normal
 block evaluates all but the final statement for declarations or side
 effects, then returns the value of the final statement.  In order to do that
-in Perl 6, you need to use one of these constructs:
+in Raku, you need to use one of these constructs:
 
     do { my $x = 42; $x }
     $( my $x = 42; $x )
@@ -2557,7 +2557,7 @@ second elements, etc.  For more on C<sort> see S29.
 
 =head2 Special variables
 
-Many of the special variables of Perl 5 are going away.  Those that apply to
+Many of the special variables of Perl are going away.  Those that apply to
 some object such as a filehandle will instead be attributes of the
 appropriate object.  Those that are truly global will have global alphabetic
 names, such as C<$*PID> or C<@*ARGS>.
@@ -2599,7 +2599,7 @@ compile time, though C<::()> can also be used to introduce an interpolation
 (see below).  Also, in the absence of another sigil, C<::> can serve as its
 own sigil indicating intentional use of a not-yet-declared package name.
 
-Unlike in Perl 5, if a sigil is followed by comma, semicolon, a colon not
+Unlike in Perl, if a sigil is followed by comma, semicolon, a colon not
 followed by an identifier, or any kind of bracket or whitespace (including
 Unicode brackets and whitespace), it will be taken to be a sigil without a
 name rather than a punctuational variable.  This allows you to use sigils as
@@ -2623,7 +2623,7 @@ Which would be the same as:
 
 =head2 Package-qualified names
 
-Ordinary package-qualified names look like they do in Perl 5:
+Ordinary package-qualified names look like they do in Perl:
 
     $Foo::Bar::baz      # the $baz variable in package Foo::Bar
 
@@ -2640,7 +2640,7 @@ The following pseudo-package names are reserved at the front of a name:
 
     MY          # Symbols in the current lexical scope (aka $?SCOPE)
     OUR         # Symbols in the current package (aka $?PACKAGE)
-    CORE        # Outermost lexical scope, definition of standard Perl
+    CORE        # Outermost lexical scope, definition of standard Raku
     GLOBAL      # Interpreter-wide package symbols, really UNIT::GLOBAL
     PROCESS     # Process-related globals (superglobals)
     COMPILING   # Lexical symbols in the scope being compiled
@@ -2668,7 +2668,7 @@ coyotes.)
 The file's scope is known as C<UNIT>, but there are one or more lexical
 scopes outside of that corresponding to the linguistic setting (often known
 as the prelude in other cultures).  Hence, the C<SETTING> scope is
-equivalent to C<UNIT::OUTERS>.  For a standard Perl program C<SETTING> is the
+equivalent to C<UNIT::OUTERS>.  For a standard Raku program C<SETTING> is the
 same as C<CORE>, but various startup options (such as C<-n> or C<-p>) can
 put you into a domain specific language, in which case C<CORE> remains the
 scope of the standard language, while C<SETTING> represents the scope
@@ -2724,7 +2724,7 @@ C<GLOBAL>, which is pretty much empty when your program starts compiling,
 and mostly only contains things you either put there yourself, or some other
 module put there because you used that module.  In general things defined
 within (or imported into) C<CORE> should only be declared or imported with
-"my" semantics.  All Perl code can see C<CORE> anyway as the outermost
+"my" semantics.  All Raku code can see C<CORE> anyway as the outermost
 lexical scope, so there's no need to also put such things into C<GLOBAL>.
 
 The C<GLOBAL> package itself is accessible via C<UNIT::GLOBAL>.  The
@@ -2801,7 +2801,7 @@ are done with this notation:
     $::($foo)::Bar::baz # $Bar::Bar::baz
     $::($foobar)baz     # ILLEGAL at compile time (no operator baz)
 
-Note that unlike in Perl 5, initial C<::> doesn't imply global.  Here as
+Note that unlike in Perl, initial C<::> doesn't imply global.  Here as
 part of the interpolation syntax it doesn't even imply package.  After the
 interpolation of the C<::()> component, the indirect name is looked up
 exactly as if it had been there in the original source code, with priority
@@ -2985,7 +2985,7 @@ are actually process globals.
 
 =head2 The C<PROCESS> package
 
-There is only ever a single C<PROCESS> package.  For an ordinary Perl
+There is only ever a single C<PROCESS> package.  For an ordinary Raku
 program running by itself, there is only one C<GLOBAL> package as well.
 However, in certain situations (such as shared hosting under a webserver),
 the actual process may contain multiple virtual processes or interpreters,
@@ -3065,7 +3065,7 @@ The following return objects that contain all pertinent info:
     $?DISTRO    Which OS distribution am I compiling under
     $?VM        Which virtual machine am I compiling under
     $?XVM       Which virtual machine am I cross-compiling for
-    $?PERL      Which Perl am I compiled for?
+    $?RAKU      Which Raku am I compiled for?
     $?SCOPE     Which lexical scope am I in?
     $?PACKAGE   Which package am I in?
     $?MODULE    Which module am I in?
@@ -3093,7 +3093,7 @@ Note that some of these things have parallels in the C<*> space at run time:
     $*KERNEL    Which kernel I'm running under
     $*DISTRO    Which OS distribution I'm running under
     $*VM        Which VM I'm running under
-    $*PERL      Which Perl I'm running under
+    $*RAKU      Which Raku I'm running under
 
 You should not assume that these will have the same value as their
 compile-time cousins.
@@ -3148,14 +3148,14 @@ the importer's namespace.
 
 =head2 Switching parsers
 
-The currently compiling Perl parser is switched by modifying one of the
+The currently compiling Raku parser is switched by modifying one of the
 braided languages in C<< COMPILING::<%?LANG> >>.  Lexically scoped parser
 changes should temporize the modification.  Changes from here to
 end-of-compilation unit can just assign or bind it.  In general, most parser
 changes involve deriving a new grammar and then pointing one of the C<<
 COMPILING::<%?LANG> >> entries at that new grammar.  Alternately, the tables
 driving the current parser can be modified without derivation, but at least
-one level of anonymous derivation must intervene from the preceding Perl
+one level of anonymous derivation must intervene from the preceding Raku
 grammar, or you might be messing up someone else's grammar.  Basically, the
 current set of grammars in C<%?LANG> has to belong only to the current
 compiling scope.  It may not be shared, at least not without explicit
@@ -3167,14 +3167,14 @@ governed, and all that.
 Individual sublanguages ("slangs") may be referred to using the C<~> twigil.
 The following are useful:
 
-    $~MAIN       the current main language (e.g. Perl statements)
+    $~MAIN       the current main language (e.g. Raku statements)
     $~Quote      the current root of quoting language
     $~Quasi      the current root of quasiquoting language
     $~Regex      the current root of regex language
     $~Trans      the current root of transliteration language
-    $~P5Regex    the current root of the Perl 5 regex language
+    $~P5Regex    the current root of the Raku regex language
 
-Hence, when you are defining a normal Perl macro, you're replacing C<$~MAIN>
+Hence, when you are defining a normal Raku macro, you're replacing C<$~MAIN>
 with a derived language, but when you define a new regex backslash sequence,
 you're replacing C<$~Regex> with a derived language.  (There may or may not
 be a syntax in the main language to do this.)  Note that such changes are
@@ -3202,7 +3202,7 @@ disable that sublanguage in the current lexical scope:
     supersede slang P5Regex {}
     m:P5/./;             # kaboom
 
-If you supersede C<MAIN> then you're replacing the Perl parser entirely.
+If you supersede C<MAIN> then you're replacing the Raku parser entirely.
 This might be done by, say, the "use COBOL" declaration. C<:-)>
 
 =head2 Extended identifiers
@@ -3254,7 +3254,7 @@ Adverbial syntax is described in L</Adverbial Pair forms>.
 
 =head1 Literals
 
-Perl 6 has a rich set of literal forms, many of which can be used for
+Raku has a rich set of literal forms, many of which can be used for
 textual input as well.  For those forms simple enough to be allowed, the
 C<val()> function treats such a string value as if it were a literal in the
 program.  In some cases the C<val()> function will be applied on your
@@ -3262,7 +3262,7 @@ behalf, and in other cases you must do so explicitly.  The rationale for
 this function is that there are many cases where the programmer or user is
 forced to use a string type to represent a value that is intended to become
 a numeric type internally.  Committing pre-emptively to either a string type
-or a numeric type is likely to be wrongish, so Perl 6 instead provides the
+or a numeric type is likely to be wrongish, so Raku instead provides the
 concept of I<allomorphic> literals.  How these work is described below in
 L<Allomorphic value semantics>.
 
@@ -3356,7 +3356,7 @@ The generic string-to-number converter will recognize all of these forms
 time).  Also allowed in strings are leading plus or minus, and maybe a
 trailing Units type for an implied scaling.  Leading and trailing whitespace
 is ignored.  Note also that leading C<0> by itself I<never> implies octal in
-Perl 6.
+Raku.
 
 In all these cases, the type produced will be the narrowest of C<Int>,
 C<Rat>, or C<Num> that can accurately represent the number.  If no type can
@@ -3383,7 +3383,7 @@ Any of the adverbial forms may be used as a function:
     :10($x)     # "dec2num"
     :16($x)     # "hex2num"
 
-Think of these as setting the default radix, not forcing it.  Like Perl 5's
+Think of these as setting the default radix, not forcing it.  Like Perl's
 old C<oct()> function, any of these will recognize a number starting with a
 different radix marker and switch to the other radix.  However, note that
 the C<:16()> converter function will interpret leading C<0b> or C<0d> as hex
@@ -3475,7 +3475,7 @@ the bracketed forms by separating the numbers with comma: C<"\x[41,42,43]">.
 You must use the bracketed form to disambiguate if the unbracketed form
 would "eat" too many characters, because all of the unbracketed forms eat as
 many characters as they think look like digits in the radix specified.  None
-of these notations work in normal Perl code.  They work only in
+of these notations work in normal Raku code.  They work only in
 interpolations and regexes and the like.
 
 Note that the inside of the brackets is not an expression, and you may not
@@ -3569,7 +3569,7 @@ Instead, one can C<().item>, or less legibly, introduce a space as in C<$(
 =head3 Disallowed forms
 
 The degenerate case C<< <> >> is disallowed as a probable attempt to do IO
-in the style of Perl 5; that is now written C<lines()>.  (C<< <STDIN> >> is
+in the style of Perl; that is now written C<lines()>.  (C<< <STDIN> >> is
 also disallowed.)  Empty lists are better written with C<()> in any case
 because C<< <> >> will often be misread as meaning C<('')>.  (Likewise the
 subscript form C<< %foo<> >> should be written C<%foo{}> to avoid misreading
@@ -3589,7 +3589,7 @@ recognized inside C<«...»> and such "words" are returned as C<Pair> objects.
 
 Colon pairs (but not arrow pairs) are recognized within double angles.  In
 addition, the double angles allow for comments beginning with C<#>.  These
-comments work exactly like ordinary comments in Perl code.  Unlike in the
+comments work exactly like ordinary comments in Raku code.  Unlike in the
 shells, any literal C<#> must be quoted, even ones without whitespace in
 front of them, but note that this comes more or less for free with a colon
 pair like C<< :char<#x263a> >>, since comments only work in double angles,
@@ -3629,7 +3629,7 @@ form to generate a C<Pair> where the key is not an identifier.
 
 Despite that restriction, it's possible for other things to come between a
 colon and its brackets; however, all of the possible non-identifier
-adverbial keys are reserved for special syntactical forms.  Perl 6 currently
+adverbial keys are reserved for special syntactical forms.  Raku currently
 recognizes decimal numbers and the null key.  In the following table the
 first and second columns do I<not> mean the same thing:
 
@@ -3671,7 +3671,7 @@ so used, the adverb is considered an integral part of the name, so C<<
 infix:<+> >> and C<< infix:<-> >> are two different operators.  Likewise C<<
 prefix:<+> >> is different from C<< infix:<+> >>.  (The notation also has
 the benefit of grouping distinct identifiers into easily accessible sets;
-this is how the standard Perl 6 grammar knows the current set of infix
+this is how the standard Raku grammar knows the current set of infix
 operators, for instance.)
 
 Only identifiers that produce a list of one or more values (preferably
@@ -3748,7 +3748,7 @@ allows:
 The other forms of adverb (including the bare C<:a> form) I<always> look for
 an immediate bracketed argument, and will slurp it up.  If that's not
 intended, you must use whitespace between the adverb and the opening
-bracket.  The syntax of individual adverbs is the same everywhere in Perl 6.
+bracket.  The syntax of individual adverbs is the same everywhere in Raku.
 There are no exceptions based on whether an argument is wanted or not.
 (There is a minor exception for quote and regex adverbs, which accept
 I<only> parentheses as their bracketing operator, and ignore other brackets,
@@ -3974,7 +3974,7 @@ with empty brackets:
 Note that this fixes the spurious "C<@>" problem in double-quoted email
 addresses.
 
-As with Perl 5 array interpolation, the elements are separated by a space.
+As with Perl array interpolation, the elements are separated by a space.
 (Except that a space is not added if the element already ends in some kind
 of whitespace.  In particular, a list of pairs will interpolate with a tab
 between the key and value, and a newline after the pair.)
@@ -4221,7 +4221,7 @@ bit happier, along with any other naïve bracket counting algorithms...)
 
 =head2 Bare identifiers
 
-There are no barewords in Perl 6.  An undeclared bare identifier will always
+There are no barewords in Raku.  An undeclared bare identifier will always
 be taken to mean a subroutine name, and be parsed as a list operator.
 (Class names (and other type names) are predeclared, or prefixed with the
 C<::> type sigil when you're declaring a new one.)  A consequence of this is
@@ -4315,7 +4315,7 @@ ref form will admit real objects in a pinch.)
 
 =head2 Hash subscripts and bare keys
 
-There is no hash subscript autoquoting in Perl 6.  Use C<< %x<foo> >> for
+There is no hash subscript autoquoting in Raku.  Use C<< %x<foo> >> for
 constant hash subscripts, or the old standby C<< %x{'foo'} >>.  (It also
 works to say C<%x«foo»> as long as you realized it's subject to
 interpolation.)
@@ -4330,7 +4330,7 @@ subject to keyword or even macro interpretation.  If you say
     }
 
 then C<$x> ends up containing the pair C<< ("if" => 1) >>.  Always.  (Unlike
-in Perl 5, where version numbers didn't autoquote.)
+in Perl, where version numbers didn't autoquote.)
 
 You can also use the C<:key($value)> form to quote the keys of option pairs.
 To align values of option pairs, you may use the "unspace" postfix forms:
@@ -4378,7 +4378,7 @@ source file.
 
 [Speculative] It may also be possible to treat a Pod object as an
 IO::Handle, to read the Pod information line-by-line (like the C<DATA>
-filehandle in Perl 5, but for I<any> Pod block).
+filehandle in Perl, but for I<any> Pod block).
 
 The lexical routine itself is C<&?ROUTINE>; you can get its name with
 C<&?ROUTINE.name>.  The current block is C<&?BLOCK>.  If the block has any
@@ -4435,14 +4435,14 @@ to match at the beginning of any whitespace.)
 
 There are two possible ways to parse heredocs.  One is to look ahead for the
 newline and grab the lines corresponding to the heredoc, and then parse the
-rest of the original line.  This is how Perl 5 does it.  Unfortunately this
-suffers from the problem pervasive in Perl 5 of multi-pass parsing, which is
-masked somewhat because there's no way to hide a newline in Perl 5.  In
-Perl 6, however, we can use "unspace" to hide a newline, which means that an
+rest of the original line.  This is how Perl does it.  Unfortunately this
+suffers from the problem pervasive in Perl of multi-pass parsing, which is
+masked somewhat because there's no way to hide a newline in Perl.  In
+Raku, however, we can use "unspace" to hide a newline, which means that an
 algorithm looking ahead to find the newline must do a full parse (with
 possible untoward side effects) in order to locate the newline.
 
-Instead, Perl 6 takes the one-pass approach, and just lazily queues up the
+Instead, Raku takes the one-pass approach, and just lazily queues up the
 heredocs it finds in a line, and waits until it sees a "real" newline to
 look for the text and attach it to the appropriate heredoc.  The downside of
 this approach is a slight restriction--you may not use the actual text of
@@ -4481,7 +4481,7 @@ must coerce a string to a C<Version>:
     v1.2.3beta                  # illegal
     Version('1.2.3beta')        # okay
 
-Note though that most places that take a version number in Perl accept it as
+Note though that most places that take a version number in Raku accept it as
 a named argument, in which case saying C<< :ver<1.2.3beta> >> is fine.  See
 S11 for more on using versioned modules.
 
@@ -4532,7 +4532,7 @@ alphabetic, and that alphabetic is defined according to Unicode, not just
 according to ASCII.  The intent of all this is to make sure that prereleases
 sort before releases.  Note also that this is still a subset of the
 versioning schemes seen in the real world.  Modules with such strange
-versions can still be used by Perl since by default Perl imports external
+versions can still be used by Raku since by default Raku imports external
 modules by exact version number.  (See S11.)  Only range operations will be
 compromised by an unknown foreign collation order, such as a system that
 sorts "delta" before "gamma".
@@ -4626,7 +4626,7 @@ type.
 
 =item *
 
-Perl still has the three main contexts: sink (aka void), item (aka scalar),
+Raku still has the three main contexts: sink (aka void), item (aka scalar),
 and list.
 
 =item *
@@ -4645,7 +4645,7 @@ containers (such as slice and hash context; see S03 for details).
 
 =item *
 
-Unlike in Perl 5, objects are no longer always considered true.  It depends
+Unlike in Perl, objects are no longer always considered true.  It depends
 on the state of their C<.Bool> method, which may either be a synthetic
 attribute or an explicitly represented bit in the object.  Classes get to
 decide which of their values are true and which are false. In general,
@@ -4674,7 +4674,7 @@ however.)
 In general any container types should return false if they are empty, and
 true otherwise.  This is true of all the standard container types except
 Scalar, which always defers the definition of truth to its contents.
-Non-container types define truthiness much as Perl 5 does, except
+Non-container types define truthiness much as Perl does, except
 that the string C<"0"> is now considered true.  Coerce to numeric with
 C<<prefix:<+> >> if you want the other semantics.
 
@@ -4688,7 +4688,7 @@ partition makes sense in control flow using boolean contexts.
 
 =head2 Lazy flattening
 
-List context in Perl 6 is by default lazy.  This means a list can contain
+List context in Raku is by default lazy.  This means a list can contain
 infinite generators without blowing up.  No flattening happens to a lazy
 list until it is bound to the signature of a function or method at call time
 (and maybe not even then).  We say that such an argument list is "lazily
@@ -4795,13 +4795,13 @@ X<..>
 The C<< .. >> operator now constructs a C<Range> object rather than merely
 functioning as an operator.  Both sides are in item context.  Semantically,
 the C<Range> acts like a list of its values to the extent possible, but does
-so lazily, unlike Perl 5's eager range operator.
+so lazily, unlike Perl's eager range operator.
 
 =head2 Hash assignment
 
 There is no such thing as a hash list context.  Assignment to a hash
 produces an ordinary list context.  You may assign alternating keys and
-values just as in Perl 5.  You may also assign lists of C<Pair> objects, in
+values just as in Perl.  You may also assign lists of C<Pair> objects, in
 which case each pair provides a key and a value.  You may, in fact, mix the
 two forms, as long as the pairs come when a key is expected.  If you wish to
 supply a C<Pair> as a key, you must compose an outer C<Pair> in which the
@@ -4852,7 +4852,7 @@ you now write
 
 =head1 Grammatical Categories
 
-Lexing in Perl 6 is controlled by a system of grammatical categories.  At
+Lexing in Raku is controlled by a system of grammatical categories.  At
 each point in the parse, the lexer knows which subset of the grammatical
 categories are possible at that point, and follows the longest-token rule
 across all the active alternatives, including those representing any

--- a/S03-operators.pod
+++ b/S03-operators.pod
@@ -13,11 +13,11 @@ Synopsis 3: Operators
 
 =head1 Overview
 
-For a summary of the changes from Perl 5, see L</Changes to Perl 5 operators>.
+For a summary of the changes from Perl, see L</Changes to Perl operators>.
 
 =head1 Operator precedence
 
-Perl 6 has about the same number of precedence levels as Perl 5,
+Raku has about the same number of precedence levels as Perl,
 but they're differently arranged in spots.  Here we list the
 levels from "tightest" to "loosest", along with a few examples of
 each level.  (Column 'A' is for "associativity", see following table.)
@@ -72,7 +72,7 @@ For unaries this is interpreted as:
     R   right     !($a!)
     N   non       ILLEGAL
 
-(In standard Perl there are no unaries that can take advantage of
+(In standard Raku there are no unaries that can take advantage of
 associativity, since at each precedence level the standard operators
 are either consistently prefix or postfix.)
 
@@ -307,7 +307,7 @@ Listop (leftward)
 
     4,3, sort 2,1       # 4,3,1,2
 
-As in Perl 5, a list operator looks like a term to the expression on
+As in Perl, a list operator looks like a term to the expression on
 its left, so it binds tighter than comma on the left but looser than
 comma on the right--see List prefix precedence below.
 
@@ -349,7 +349,7 @@ Class-qualified method call
     $obj.::Class::meth
     $obj.Class::meth    # same thing, assuming Class is predeclared
 
-As in Perl 5, tells the dispatcher which class to start searching from,
+As in Perl, tells the dispatcher which class to start searching from,
 not the exact method to call.
 
 =item *
@@ -412,7 +412,7 @@ There is specifically no C<< infix:<.> >> operator, so
 
 will always result in a compile-time error indicating the user should
 use C<< infix:<~> >> instead.  This is to catch an error likely to
-be made by Perl 5 programmers learning Perl 6.
+be made by Perl programmers learning Raku.
 
 =back
 
@@ -425,7 +425,7 @@ to a single mutating object in the same expression may result in undefined
 behavior unless some explicit sequencing operator is interposed.
 See L</Sequence points>.
 
-As with all postfix operators in Perl 6, no space is allowed between
+As with all postfix operators in Raku, no space is allowed between
 a term and its postfix.  See L<S02> for why, and for how to work around the
 restriction with an "unspace".
 
@@ -439,16 +439,16 @@ support the common idiom:
     say $x unless %seen{$x}++;
 
 Increment of a C<Str> (in a suitable container) works similarly to
-Perl 5, but is generalized slightly.
+Perl, but is generalized slightly.
 A scan is made for the final alphanumeric sequence in
-the string that is not preceded by a '.' character.  Unlike in Perl 5, this
+the string that is not preceded by a '.' character.  Unlike in Perl, this
 alphanumeric sequence need not be anchored to the beginning of the
 string, nor does it need to begin with an alphabetic character;
 the final sequence in the string matching C<< <!after '.'> <rangechar>+ >>
 is incremented regardless of what comes before it.
 
 The C<< <rangechar> >> character class is defined as that subset of
-characters that Perl knows how to increment within a range, as defined
+characters that Raku knows how to increment within a range, as defined
 below.
 
 The additional matching behaviors provide two useful benefits:
@@ -480,7 +480,7 @@ in such a range, it wraps to the first character of the range and
 sends a "carry" to the position left of it, and that position is
 then incremented in its own range.  If and only if the leftmost
 position is exhausted in its range, an additional character of the
-same range is inserted to hold the carry in the same fashion as Perl 5,
+same range is inserted to hold the carry in the same fashion as Perl,
 so incrementing '(zz99)' turns into '(aaa00)' and incrementing
 '(99zz)' turns into '(100aa)'.
 
@@ -515,7 +515,7 @@ Ranges that are open-ended simply because Unicode has not defined
 codepoints for them (yet?) are counted as rangechars, but are
 specifically excluded from "carry" semantics, because Unicode may add
 those codepoints in the future.  (This has already happened with the
-circled numbers, for instance!)  For such ranges, Perl will pretend
+circled numbers, for instance!)  For such ranges, Raku will pretend
 that the characters are contiguous for calculating successors and
 predecessors, and will fail if you run off of either end.
 
@@ -527,7 +527,7 @@ predecessors, and will fail if you run off of either end.
     ❶..❿        # dingbat negative circled 1..10
       etc.
 
-Note: for actual ranges in Perl you'll need to quote the characters above:
+Note: for actual ranges in Raku you'll need to quote the characters above:
 
     '⓪'..'㊿'   # circled digits/numbers 0..50
 
@@ -549,7 +549,7 @@ we can't just increment unrecognized characters, because
 we have to locate the string's final sequence of rangechars before knowing
 which portion of the string to increment.
 
-Perl 6 also supports C<Str> decrement with similar semantics, simply by
+Raku also supports C<Str> decrement with similar semantics, simply by
 running the cycles the other direction.  However, leftmost characters
 are never removed, and the decrement fails when you reach a string like
 "aaa" or "000".
@@ -653,8 +653,8 @@ C<< prefix:<+> >>, numeric context
 
     +$x
 
-Unlike in Perl 5, where C<+> is a no-op, this operator coerces to
-numeric context in Perl 6.  (It coerces only the value, not the
+Unlike in Perl, where C<+> is a no-op, this operator coerces to
+numeric context in Raky.  (It coerces only the value, not the
 original variable.)  For values that do not already do the
 C<Numeric> role, the narrowest appropriate type of C<Int>, C<Rat>, C<Num>, or
 C<Complex> will be returned; however, string containing two integers
@@ -1071,7 +1071,7 @@ string value the number of times specified by the right argument, and
 returns the result as a single concatenated string regardless of context.
 
 If the count is less than 1, returns the null string.
-The count may not be C<*> because Perl 6 does not support
+The count may not be C<*> because Raky does not support
 infinite strings.  (At least, not yet...)  Note, however, that an
 infinite string may someday be emulated with C<cat($string xx *)>,
 in which case C<$string x *> may be a shorthand for that.
@@ -1187,10 +1187,10 @@ Operators of one argument
     let
     temp
 
-Note that, unlike in Perl 5, you must use the C<.meth> forms to default
-to C<$_> in Perl 6.
+Note that, unlike in Perl, you must use the C<.meth> forms to default
+to C<$_> in Raku.
 
-There is no unary C<rand> prefix in Perl 6, though there is a C<.rand>
+There is no unary C<rand> prefix in Raku, though there is a C<.rand>
 method call and an argumentless C<rand> term.   There is no unary C<int>
 prefix either; you must use a typecast to a type such as C<Int> or C<int>.
 (Typecasts require parentheses and may not be used as prefix operators.)
@@ -1258,7 +1258,7 @@ C<< infix:<==> >> etc.
 
     == != < <= > >=
 
-As in Perl 5, converts to C<Num> before comparison.  C<!=> is short for C<!==>.
+As in Perl, converts to C<Num> before comparison.  C<!=> is short for C<!==>.
 
 =item *
 
@@ -1266,7 +1266,7 @@ C<< infix:<eq> >> etc.
 
     eq ne lt le gt ge
 
-As in Perl 5, converts to C<Str> before comparison. C<ne> is short for C<!eq>.
+As in Perl, converts to C<Str> before comparison. C<ne> is short for C<!eq>.
 
 =item *
 
@@ -1281,10 +1281,10 @@ Smart match
 
     $obj ~~ $pattern
 
-Perl 5's C<=~> becomes the "smart match" operator C<~~>, with an
+Perl's C<=~> becomes the "smart match" operator C<~~>, with an
 extended set of semantics.  See L</Smart matching> for details.
 
-To catch "brainos", the Perl 6 parser defines an C<< infix:<=~> >>
+To catch "brainos", the Raku parser defines an C<< infix:<=~> >>
 operator, which always fails at compile time with a message directing
 the user to use C<~~> or C<~=> (string append) instead if they meant
 it as a single operator, or to put a space between if they really
@@ -1330,7 +1330,7 @@ Canonical equivalence
 Compares two objects for canonical equivalence.  For value types compares
 the values.  For object types, compares current contents according to some
 scheme of canonicalization.  These semantics are those used by hashes
-that allow only values for keys (such as Perl 5 string-key hashes).
+that allow only values for keys (such as Perl string-key hashes).
 See also L</Comparison semantics>.
 
 Note that C<eqv> autothreads over junctions, as do all other comparison
@@ -1390,7 +1390,7 @@ returns the result of the last argument.  It is specifically allowed
 to use a list or array both as a boolean and as a list value produced
 if the boolean is true:
 
-    @a = @b || @c;              # broken in Perl 5; works in Perl 6
+    @a = @b || @c;              # broken in Perl; works in Raku
 
 In list context this operator forces a false return to mean C<()>.
 See C<or> below for low-precedence version.
@@ -1516,7 +1516,7 @@ The best don't-repeat-yourself solution is simply:
 C<< infix:<?> >>
 
 To catch likely errors by people familiar with C-derived languages
-(including Perl 5), a bare question mark in infix position will
+(including Perl), a bare question mark in infix position will
 produce an error suggesting that the user use C<?? !!> instead.
 
 =item *
@@ -1612,7 +1612,7 @@ a C<Pair> object that can, among other things, be used to pass named
 arguments to functions.  It provides item context to both sides.
 It does not actually do an assignment except in a notional sense;
 however its precedence is now equivalent to assignment, and it is
-also right associative.  Note that, unlike in Perl 5, C<< => >>
+also right associative.  Note that, unlike in Perl, C<< => >>
 binds more tightly than comma.
 
 =item *
@@ -1663,7 +1663,7 @@ C<< infix:<,> >>, the argument separator
 
     1, 2, 3, @many
 
-Unlike in Perl 5, comma operator never returns the last value.  (In item
+Unlike in Perl, comma operator never returns the last value.  (In item
 context it returns a list instead.)
 
 =item *
@@ -2221,13 +2221,13 @@ you're interested in.  Perhaps there can be a generic method,
 that will take any given sequence and use it as the universe of incrementation
 for any matching characters in the string.
 
-To preserve Perl 5 length limiting semantics of a range like
+To preserve Perl length limiting semantics of a range like
 C<'A'..'zzz'>, you'd need something like:
 
     'A', *.succ ... { last if .chars > 3; $_ eq 'zzz' }
 
-(That's not an exact match to what Perl 5 does, since C<Str.succ> is
-a bit fancier in Perl 6, but starting with 'A' it'll work the same.
+(That's not an exact match to what Perl does, since C<Str.succ> is
+a bit fancier in Raku, but starting with 'A' it'll work the same.
 You can always supply your own increment function.)
 
 Note that the C<last> call above returns no argument, so even though
@@ -2371,16 +2371,16 @@ C<< infix:<:=> >>, run-time binding
 
     $signature := $capture
 
-A new form of assignment is present in Perl 6, called I<binding>, used in
+A new form of assignment is present in Raku, called I<binding>, used in
 place of typeglob assignment.  It is performed with the C<:=> operator.
 Instead of replacing the value in a container like normal assignment, it
 replaces the container itself.  For instance:
 
     my $x = 'Just Another';
     my $y := $x;
-    $y = 'Perl Hacker';
+    $y = 'Raku Hacker';
 
-After this, both C<$x> and C<$y> contain the string C<"Perl Hacker">,
+After this, both C<$x> and C<$y> contain the string C<"Raku Hacker">,
 since they are really just two different names for the same variable.
 
 There is also an identity test, C<=:=>, which tests whether two names
@@ -2515,7 +2515,7 @@ The C<item> contextualizer
 
     item foo()
 
-The new name for Perl 5's C<scalar> contextualizer.  Equivalent to C<$(...)>
+The new name for Perl's C<scalar> contextualizer.  Equivalent to C<$(...)>
 (except that empty C<$()> means C<$($/.made // ~$/)>, while empty C<item()> yields C<Failure>).
 We still call the values scalars, and talk about "scalar operators", but
 scalar operators are those that put their arguments into item context.
@@ -2749,7 +2749,7 @@ followed by the comma operator.
 
 =back
 
-=head1 Changes to Perl 5 operators
+=head1 Changes to Perl operators
 
 Several operators have been given new names to increase clarity and better
 Huffman-code the language, while others have changed precedence.
@@ -2758,19 +2758,19 @@ Huffman-code the language, while others have changed precedence.
 
 =item *
 
-Perl 5's C<${...}>, C<@{...}>, C<%{...}>, etc. dereferencing
+Perl's C<${...}>, C<@{...}>, C<%{...}>, etc. dereferencing
 forms are now C<$(...)>, C<@(...)>, C<%(...)>, etc. instead.
-(Use of the Perl 5 curly forms will result in an error message
+(Use of the Perl curly forms will result in an error message
 pointing the user to the new forms.)
-As in Perl 5, the parens may be dropped when dereferencing
+As in Perl, the parens may be dropped when dereferencing
 a scalar variable.
 
 =item *
 
 C<< -> >> becomes C<.>, like the rest of the world uses.  There is
 a pseudo C<< postfix:«->» >> operator that produces a compile-time
-error reminding Perl 5 users to use dot instead.  (The "pointy block"
-use of C<< -> >> in Perl 6 requires preceding whitespace when the arrow
+error reminding Perl users to use dot instead.  (The "pointy block"
+use of C<< -> >> in Raku requires preceding whitespace when the arrow
 could be confused with a postfix, that is, when an infix is expected.
 Preceding whitespace is not required in term position.)
 
@@ -2851,7 +2851,7 @@ though that's a silly example since you could just write:
 But that demonstrates the other advantage of the method form, which is
 that it allows the "unary dot" syntax to test the current topic.
 
-Unlike in earlier versions of Perl 6, these filetest methods do not return
+Unlike in earlier versions of Raku, these filetest methods do not return
 stat buffers, but simple scalars of type C<Bool>, C<Int>, or C<Instant>.
 
 In general, the user need not worry about caching the stat buffer
@@ -2863,7 +2863,7 @@ object that will not be subject to timeout, and may be tested
 repeatedly just as a filename or handle can.  An C<IO> object has
 a C<.path> method that can be queried for its path (if known).
 
-(Inadvertent use of the Perl 5 forms will normally result in treatment
+(Inadvertent use of the Perl forms will normally result in treatment
 as a negated postdeclared subroutine, which is likely to produce an
 error message at the end of compilation.)
 
@@ -2889,12 +2889,12 @@ Writing C<$object.'='> will call your prefix operator.
 
 Unary C<~> now imposes a string (C<Stringy>) context on its
 argument, and C<+> imposes a numeric (C<Numeric>) context (as opposed
-to being a no-op in Perl 5).  Along the same lines, C<?> imposes
+to being a no-op in Perl).  Along the same lines, C<?> imposes
 a boolean (C<Bool>) context, and the C<|> unary operator imposes
 a function-arguments (C<List> or C<Capture>) context on its argument.
 Unary sigils are allowed when followed by a C<$> sigil on a scalar variable;
 they impose the container context implied by their sigil.
-As with Perl 5, however, C<$$foo[bar]> parses as C<( $($foo) )[bar]>,
+As with Perl, however, C<$$foo[bar]> parses as C<( $($foo) )[bar]>,
 so you need C<$($foo[bar])> to mean the other way.  In other
 words, sigils are not really parsed as operators, and you must
 use the parenthetical form for anything complicated.
@@ -2902,17 +2902,17 @@ use the parenthetical form for anything complicated.
 =item *
 
 Bitwise operators get a data type prefix: C<+>, C<~>, or C<?>.
-For example, Perl 5's C<|> becomes either C<+|> or C<~|> or C<?|>,
+For example, Perl's C<|> becomes either C<+|> or C<~|> or C<?|>,
 depending on whether the operands are to be treated as numbers,
-strings, or boolean values.  Perl 5's left shift C< << > becomes
-C< +< >, and correspondingly with right shift. Perl 5's unary C<~>
+strings, or boolean values.  Perl's left shift C< << > becomes
+C< +< >, and correspondingly with right shift. Perl's unary C<~>
 (one's complement) becomes either C<+^> or C<~^> or C<?^>, since a
 bitwise NOT is like an exclusive-or against solid ones.  Note that
 C<?^> is functionally identical to C<!>, but conceptually coerces to
 boolean first and then flips the bit.  Please use C<!> instead. As
 explained in L</Assignment operators>, a bitwise operator can be turned
 into its corresponding assignment operator by following it with C<=>.
-For example Perl 5's C< <<= > becomes C< +<= >.
+For example Perl's C< <<= > becomes C< +<= >.
 
 C<?|> is a logical OR but differs from C<||> in that C<?|> always
 evaluates both sides and returns a standard boolean value.  That is,
@@ -2979,7 +2979,7 @@ The old C<..> flipflop operator is now done with
 C<ff> operator.  (C<..> now always produces a C<Range> object
 even in item context.)  The C<ff> operator may take a caret on
 either end to exclude either the beginning or ending.  There is
-also a corresponding C<fff> operator with Perl 5's C<...> semantics.
+also a corresponding C<fff> operator with Perl's C<...> semantics.
 
 The two sides of a flipflop are evaluated as smartmatches against
 the current value of the topic stored in C<$_>.  For instance, you may say
@@ -2993,7 +2993,7 @@ never flops once flipped.
 The state of a flipflop is kept in an anonymous state variable, so separate
 closure clones get their own states.
 
-Note that unlike Perl 5's flipflop, numeric values are not
+Note that unlike Perl's flipflop, numeric values are not
 automatically checked against the current line number.  (If you
 wish to have those semantics for your smartmatches, you could mixin
 a numeric value to C<$_> to create a chimeric object that is both
@@ -3042,10 +3042,10 @@ This, however, warns you of information loss:
 
     ($a, $b, $c) = 1, 2, 3, 4;
 
-As in Perl 5, assignment to an array or hash slurps up all the
+As in Perl, assignment to an array or hash slurps up all the
 remaining values, and can never produce such a warning.  (It will,
 however, leave any subsequent lvalue containers with no elements,
-just as in Perl 5.)
+just as in Perl.)
 
 The left side is evaluated completely for its sequence of containers before
 any assignment is done.  Therefore this:
@@ -3066,7 +3066,7 @@ works as a C programmer would expect.   The term on the right of the
 C<=> is always evaluated in item context.
 
 The syntactic distinction between item and list assignment is similar
-to the way Perl 5 defines it, but has to be a little different because
+to the way Perl defines it, but has to be a little different because
 we can no longer decide the nature of an inner subscript on the basis
 of the outer sigil.  So instead, item assignment is restricted to
 lvalues that are simple scalar variables, and assignment to anything
@@ -3147,9 +3147,9 @@ syntax.
 
 =item *
 
-List operators are all parsed consistently.  As in Perl 5,
+List operators are all parsed consistently.  As in Perl,
 to the left a list operator looks like a term, while to the right it looks like
-an operator that is looser than comma.  Unlike in Perl 5, the difference
+an operator that is looser than comma.  Unlike in Perl, the difference
 between the list operator form and the function form is consistently
 indicated via whitespace between the list operator and the first
 argument.  If there is whitespace, it is always a list operator,
@@ -3203,7 +3203,7 @@ Examples:
     say foo <$bar+1>,$baz               say(foo(<$bar+1>, $baz));
     say foo .<$bar+1>,$baz              say(foo($_.<$bar+1>, $baz));
 
-Note that Perl 6 is making a consistent three-way distinction between
+Note that Raku is making a consistent three-way distinction between
 term vs postfix vs infix, and will interpret an overloaded character
 like C<< < >> accordingly:
 
@@ -3212,9 +3212,9 @@ like C<< < >> accordingly:
     any() < $x                  (any) < $x              # infix
     any<a b c>                  ILLEGAL                 # stealth postfix
 
-This will seem unfamiliar and "undwimmy" to Perl 5 programmers, who
+This will seem unfamiliar and "undwimmy" to Perl programmers, who
 are used to a grammar that sloppily hardwires a few postfix operators
-at the price of extensibility.  Perl 6 chooses instead to mandate a
+at the price of extensibility.  Raku chooses instead to mandate a
 whitespace dependency in order to gain a completely extensible class
 of postfix operators.
 
@@ -3256,7 +3256,7 @@ as an enum declaration.  Such a term never looks for its arguments,
 is never considered a list prefix operator, and may not work with
 subsequent parentheses because it will be parsed as a function call
 instead of the intended term.  (The function in question may or
-may not exist.)  For example, C<rand> is a simple term in Perl 6
+may not exist.)  For example, C<rand> is a simple term in Raku
 and does not allow parens, because there is no C<rand()> function
 (though there's a C<$n.rand> method).  Most constant values such as
 C<e> and C<pi> are in the same category.  After parsing one of these
@@ -3287,7 +3287,7 @@ All other subs with arguments parse as list operators.
 =head1 Junctive operators
 
 C<|>, C<&>, and C<^> are no longer bitwise operators (see
-L</Changes to Perl 5 operators>) but now serve a much higher cause:
+L</Changes to Perl operators>) but now serve a much higher cause:
 they are now the junction constructors.
 
 A junction is a single value that is equivalent to multiple values. They
@@ -3362,7 +3362,7 @@ which are instead classified as chaining operators).
 
 =item *
 
-Perl 5's comparison operators are basically unchanged, except that they
+Perl's comparison operators are basically unchanged, except that they
 can be chained because their precedence is unified.
 
 =item *
@@ -3407,7 +3407,7 @@ If that's not enough flexibility, there is also an C<eqv()> function
 that can be passed additional information specifying how you want
 canonical values to be generated before comparison.  This gives
 C<eqv()> the same kind of expressive power as a sort signature.
-(And indeed, the C<cmp> operator from Perl 5 also has a functional
+(And indeed, the C<cmp> operator from Perl also has a functional
 analog, C<cmp()>, that takes additional instructions on how to
 do 3-way comparisons of the kind that a sorting algorithm wants.)
 In particular, a signature passed to C<eqv()> will be bound to the
@@ -3421,7 +3421,7 @@ reverts to standard C<eqv> comparison.  (Likewise for C<cmp()>.)
 =item *
 
 Binary C<cmp> is no longer the comparison operator that
-forces stringification.  Use the C<leg> operator for the old Perl 5
+forces stringification.  Use the C<leg> operator for the old Perl
 C<cmp> semantics.  The C<cmp> is just like the C<eqv> above except that
 instead of returning C<Bool::False> or C<Bool::True> values it always
 returns C<Order::Less>, C<Order::Same>, or C<Order::More>
@@ -3655,7 +3655,7 @@ generally overloaded to do something sensible on C<Range> objects.
 
 =head1 Chained comparisons
 
-Perl 6 supports the natural extension to the comparison operators,
+Raku supports the natural extension to the comparison operators,
 allowing multiple operands:
 
     if 1 < $a < 100 { say "Good, you picked a number *between* 1 and 100." }
@@ -3677,8 +3677,8 @@ in front of it, or it will be interpreted as a hash subscript instead.
 
 =head1 Smart matching
 
-Here is the table of smart matches for standard Perl 6
-(that is, the dialect of Perl in effect at the start of your
+Here is the table of smart matches for standard Raku
+(that is, the dialect of Raku in effect at the start of your
 compilation unit).  Smart matching is generally done on the current
 "topic", that is, on C<$_>.  In the table below, C<$_> represents the
 left side of the C<~~> operator, or the argument to a C<given>,
@@ -3698,7 +3698,7 @@ that no additional match operators are defined after compile time,
 so if the pattern types are evident at compile time, the jump table
 can be optimized.  However, the syntax of this part of the table
 is still somewhat privileged, insofar as the C<~~> operator is one
-of the few operators in Perl that does not use multiple dispatch.
+of the few operators in Raku that does not use multiple dispatch.
 Instead, type-based smart matches singly dispatch to an underlying
 method belonging to the C<X> pattern object.
 
@@ -4021,7 +4021,7 @@ less interchangeably.
 =head1 Invocant marker
 
 An appended C<:> marks the invocant when using the indirect-object
-syntax for Perl 6 method calls.  The following two statements are
+syntax for Raku method calls.  The following two statements are
 equivalent:
 
     $hacker.feed('Pizza and cola');
@@ -4087,7 +4087,7 @@ more of the (less-than-obvious) details on these two operators.
 
 =head1 Meta operators
 
-Perl 6's operators have been greatly regularized, for instance, by
+Raku's operators have been greatly regularized, for instance, by
 consistently prefixing numeric, stringwise, and boolean operators
 with C<+>, C<~> and C<?> respectively to indicate whether the bitwise
 operation is done on a number, a string, or a single bit.
@@ -4096,10 +4096,10 @@ bitwise C<¬> operator, you'd have to add the C<+¬>, C<~¬>, and C<?¬>
 operators yourself.  Similarly, the carets that exclude the endpoints
 on ranges are there by convention only.
 
-In contrast to that, Perl 6 has eight standard metaoperators for
+In contrast to that, Raku has eight standard metaoperators for
 turning a given existing operator into a related operator that is
 more powerful (or at least differently powerful).  These differ from a
-mere naming convention in that Perl automatically generates these new
+mere naming convention in that Raku automatically generates these new
 operators from user-defined operators as well as from builtins.
 In fact, you're not generally supposed to define the individual
 metaoperations--their semantics are supposed to be self-evident by
@@ -4339,7 +4339,7 @@ identical shape, a result of that same shape is produced.  Otherwise
 the result depends on how you write the hyper markers.
 
 For an infix operator, if either argument is insufficiently
-dimensioned, Perl "upgrades" it, but only if you point the "sharp" end
+dimensioned, Raku "upgrades" it, but only if you point the "sharp" end
 of the hypermarker at it.
 
      (3,8,2,9,3,8) >>->> 1;          # (2,7,1,8,2,7)
@@ -4356,12 +4356,12 @@ be underdimensioned, you can dwim on both sides:
 
     $left «*» $right
 
-[Note: if you are worried about Perl getting confused by something like this:
+[Note: if you are worried about Raku getting confused by something like this:
 
     func «*»
 
 then you shouldn't worry about it, because unlike previous versions,
-Perl 6 never guesses whether the next thing is a term or operator.
+Raku never guesses whether the next thing is a term or operator.
 In this case it is always expecting a term unless C<func> is predeclared
 to be a type or value name.]
 
@@ -5098,15 +5098,15 @@ container, which in turn depends on which declarator you use).
     state $foo = 1;      # happens at execute time, but only once
     constant $foo = 1;   # happens at BEGIN time
 
-(Note that the semantics of C<our> are different from Perl 5, where the
+(Note that the semantics of C<our> are different from Perl, where the
 initialization happens at the same time as a C<my>.  To get the same
-effect in Perl 6 you'd have to say "C<(our $foo) = 1;>" instead.)
+effect in Raku you'd have to say "C<(our $foo) = 1;>" instead.)
 
 If you do not initialize a container, it starts out undefined at the
 beginning of its natural lifetime.  (In other words, you can't use
-the old Perl 5 trick of "C<my $foo if 0>" to get a static variable,
+the old Perl trick of "C<my $foo if 0>" to get a static variable,
 because a C<my> variable starts out uninitialized every time through
-in Perl 6 rather than retaining its previous value.)  Native integer
+in Raku rather than retaining its previous value.)  Native integer
 containers that do not support the concept of undefined should be
 initialized to 0 instead.  (Native floating-point containers are
 by default initialized to C<NaN>.)  Typed object containers start
@@ -5236,8 +5236,8 @@ it can initialize to a different readonly value:
 
 =head1 Argument List Interpolating
 
-Perl 5 forced interpolation of a function's argument list by use of
-the C<&> prefix.  That option is no longer available in Perl 6, so
+Perl forced interpolation of a function's argument list by use of
+the C<&> prefix.  That option is no longer available in Raku, so
 instead the C<|> prefix operator serves as an
 interpolator, by casting its operand to a C<Capture> object
 and inserting the capture's parts into the current argument list.
@@ -5307,7 +5307,7 @@ as well as the C<< <> >>, C<< .<> >>, C<«»>, and C<.«»> constant and
 interpolating slice subscripting forms.
 
 The C<|> operator interpolates lazily for C<Array> and C<Range> objects.
-To get an immediate interpolation like Perl 5 does, add the C<eager> list
+To get an immediate interpolation like Perl does, add the C<eager> list
 operator:
 
     func(|(1..Inf));       # works fine
@@ -5337,7 +5337,7 @@ its bits at once using the C<< prefix:<|> >> operator:
 
 =head1 Traversing arrays in parallel
 
-In order to support parallel iteration over multiple arrays, Perl 6
+In order to support parallel iteration over multiple arrays, Raku
 has a C<zip> function that builds a list of C<List> objects from the
 elements of two or more arrays.  In ordinary list context this behaves
 as a list of C<Captures> and automatically flattens.

--- a/S04-control.pod
+++ b/S04-control.pod
@@ -12,7 +12,7 @@ Synopsis 4: Blocks and Statements
     Version: 141
 
 This document summarizes Apocalypse 4, which covers the block and
-statement syntax of Perl.
+statement syntax of Raku.
 
 =head1 The Relationship of Lexical and Dynamic Scopes
 
@@ -43,7 +43,7 @@ up the dynamic call stack for a variable of a particular name, but at each
 "stop" along the way, they are actually looking in the lexical "pad"
 associated with that particular dynamic scope's call frame.
 
-In Perl 6, control flow is designed to do what the user expects most of the
+In Raku, control flow is designed to do what the user expects most of the
 time, but this implies that we must consider the declarative nature of
 labels and blocks and combine those with the dynamic nature of the call
 stack.  For instance, a C<return> statement always returns from the
@@ -53,7 +53,7 @@ internal to the subroutine's current call frame.  The lexical scope supplies
 the declared target for the dynamic operation.  There does not seem to be a
 prevailing term in the industry for this, so we've coined the term
 I<lexotic> to refer to these strange operations that perform a dynamic
-operation with a lexical target in mind.  Lexotic operators in Perl 6
+operation with a lexical target in mind.  Lexotic operators in Raku
 include:
 
     return
@@ -93,7 +93,7 @@ all work the same on the inside.
 
 Blocks are delimited by curlies, or by the beginning and end of the current
 compilation unit (either the current file or the current C<EVAL> string).
-Unlike in Perl 5, there are (by policy) no implicit blocks around standard
+Unlike in Perl, there are (by policy) no implicit blocks around standard
 control structures.  (You could write a macro that violates this, but resist
 the urge.)  Variables that mediate between an outer statement and an inner
 block (such as loop variables) should generally be declared as formal
@@ -120,7 +120,7 @@ enclosing block.  Period.  Lexicals may not "leak" from a block to any other
 external scope (at least, not without some explicit aliasing action on the
 part of the block, such as exportation of a symbol from a module).  The
 "point of declaration" is the moment the compiler sees "C<my $foo>", not the
-end of the statement as in Perl 5, so
+end of the statement as in Perl, so
 
     my $x = $x;
 
@@ -154,7 +154,7 @@ detected because it is hidden in an C<EVAL>, then it is erroneous, since the
 C<EVAL()> compiler might bind to either C<$OUTER::x> or the subsequently
 declared "C<my $x>".
 
-As in Perl 5, "C<our $foo>" introduces a lexically scoped alias for a
+As in Perl, "C<our $foo>" introduces a lexically scoped alias for a
 variable in the current package.
 
 The new C<constant> declarator introduces a compile-time constant, either a
@@ -174,13 +174,13 @@ beginning of the next.  Separate clones of the closure get separate state
 variables.  However, recursive calls to the same clone use the same state
 variable.
 
-Perl 5's "C<local>" function has been renamed to C<temp> to better reflect
+Perl's "C<local>" function has been renamed to C<temp> to better reflect
 what it does.  There is also a C<let> prefix operator that sets a
 hypothetical value.  It works exactly like C<temp>, except that the value
 will be restored only if the current block exits unsuccessfully.  (See
 Definition of Success below for more.)  C<temp> and C<let> temporize or
 hypotheticalize the value or the variable depending on whether you do
-assignment or binding.  One other difference from Perl 5 is that the default
+assignment or binding.  One other difference from Perl is that the default
 is not to undefine a variable.  So
 
     temp $x;
@@ -189,7 +189,7 @@ causes C<$x> to start with its current value.  Use
 
     undefine temp $x;
 
-to get the Perl 5 behavior.
+to get the Perl behavior.
 
 Note that temporizations that are undone upon scope exit must be prepared to
 be redone if a continuation within that scope is taken.
@@ -204,9 +204,9 @@ lower-level list of statements and, while they may be a final statement in
 their subscope, they're not considered the final statement of the outer
 block in question.
 
-This is subtly different from Perl 5's behavior, which was to return the
+This is subtly different from Perl's behavior, which was to return the
 value of the last expression evaluated, even if that expression was just a
-conditional.  Unlike in Perl 5, if a final statement in Perl 6 is a
+conditional.  Unlike in Perl, if a final statement in Raku is a
 conditional that does not execute any of its branches, it doesn't matter
 what the value of the conditional is, the value of that conditional
 statement is always C<()>.  If there are no statements in the block at all,
@@ -257,7 +257,7 @@ they are naturally terminated by some other statement terminator:
 =head1 Conditional statements
 X<if>X<unless>
 
-The C<if> and C<unless> statements work much as they do in Perl 5.  However,
+The C<if> and C<unless> statements work much as they do in Perl.  However,
 you may omit the parentheses on the conditional:
 
     if $foo == 123 {
@@ -274,7 +274,7 @@ The result of a conditional statement is the result of the block chosen to
 execute.  If the conditional does not execute any branch, the return value
 is C<()>.
 
-The C<unless> statement does not allow an C<elsif> or C<else> in Perl 6.
+The C<unless> statement does not allow an C<elsif> or C<else> in Raku.
 
 The value of the conditional expression may be optionally bound to a closure
 parameter:
@@ -284,7 +284,7 @@ parameter:
     else          -> $b { say $b }
 
 Note that the value being evaluated for truth and subsequently bound is not
-necessarily a value of type C<Bool>.  (All normal types in Perl may be
+necessarily a value of type C<Bool>.  (All normal types in Raku may be
 evaluated for truth.  In fact, this construct would be relatively useless if
 you could bind only boolean values as parameters, since within the closure
 you already know whether it evaluated to true or false.)  Binding within an
@@ -312,7 +312,7 @@ where each call to the block would bind a new invocant for the C<.waste>
 method, each of which is likely different from the original invocant to the
 C<.haste> method.)
 
-Conditional statement modifiers work as in Perl 5.  So do the implicit
+Conditional statement modifiers work as in Perl.  So do the implicit
 conditionals implied by short-circuit operators.  Note though that the
 contents of parens or brackets is parsed as a statement, so you can say:
 
@@ -354,13 +354,13 @@ There are also C<with> and C<without> statement modifiers:
 
 =head1 Loop statements
 
-Looping statement modifiers are the same as in Perl 5 except that, for ease
+Looping statement modifiers are the same as in Perl except that, for ease
 of writing list comprehensions, a looping statement modifier is allowed to
 contain a single conditional statement modifier:
 
     @evens = ($_ * 2 if .odd for 0..100);
 
-Loop modifiers C<next>, C<last>, and C<redo> also work much as in Perl 5.
+Loop modifiers C<next>, C<last>, and C<redo> also work much as in Perl.
 However, the labeled forms can use method call syntax: C<LABEL.next>, etc.
 The C<.next> and C<.last> methods take an optional argument giving the final
 value of that loop iteration.  So the old C<next LINE> syntax is still
@@ -392,7 +392,7 @@ and C<take>.
 =head2 The C<while> and C<until> statements
 X<while>X<until>
 
-The C<while> and C<until> statements work as in Perl 5, except that you may
+The C<while> and C<until> statements work as in Perl, except that you may
 leave out the parentheses around the conditional:
 
     while $bar < 100 {
@@ -418,7 +418,7 @@ generally use C<for> to iterate filehandles.
 =head2 The C<repeat> statement
 X<repeat>X<while>X<next>X<last>X<redo>
 
-Unlike in Perl 5, applying a statement modifier to a C<do> block is
+Unlike in Perl, applying a statement modifier to a C<do> block is
 specifically disallowed:
 
     do {
@@ -437,7 +437,7 @@ or equivalently:
         ...
     } until $x >= 10;
 
-Unlike Perl 5's C<do-while> loop, this is a real loop block now, so C<next>,
+Unlike Perl's C<do-while> loop, this is a real loop block now, so C<next>,
 C<last>, and C<redo> work as expected.  The loop conditional on a C<repeat>
 block is required, so it will be recognized even if you put it on a line by
 its own:
@@ -506,7 +506,7 @@ is equivalent to the C-ish idiom:
 X<for>X<zip>X<Z>X<STDIN>X<$*IN>X<lines>
 
 There is no C<foreach> statement any more. It's always spelled C<for> in
-Perl 6, so it always takes a list as an argument:
+Raku, so it always takes a list as an argument:
 
     for @foo { .print }
 
@@ -527,11 +527,11 @@ that can be bound to the corresponding number of parameters:
     for @a Z @b -> ($a, $b) { print "[$a, $b]\n" }        # same thing
 
 The list is evaluated lazily by default, so instead of using a C<while> to
-read a file a line at a time as you would in Perl 5:
+read a file a line at a time as you would in Perl:
 
     while (my $line = <STDIN>) {...}
 
-in Perl 6 you should use a C<for> instead:
+in Raku you should use a C<for> instead:
 
     for $*IN.lines -> $line {...}
 
@@ -545,11 +545,11 @@ block scopes.)  It is also possible to write
 However, this is likely to fail on autochomped filehandles, so use the
 C<for> loop instead.
 
-Note also that Perl 5's special rule causing
+Note also that Perl's special rule causing
 
     while (<>) {...}
 
-to automatically assign to C<$_> is not carried over to Perl 6.  That should
+to automatically assign to C<$_> is not carried over to Raku.  That should
 now be written:
 
     for lines() {...}
@@ -606,7 +606,7 @@ statement_control:<for> >> because it always calls a closure.
 
 =head2 The do-once loop
 
-In Perl 5, a bare block is deemed to be a do-once loop.  In Perl 6, the bare
+In Perl, a bare block is deemed to be a do-once loop.  In Raku, the bare
 block is not a do-once.  Instead C<do {...}> is the do-once loop (which is
 another reason you can't put a statement modifier on it; use C<repeat> for a
 test-at-the-end loop).
@@ -658,7 +658,7 @@ loop control statements.
 In any sequence of statements, only the value of the final statement is
 returned, so all prior statements are evaluated in sink context, which is
 automatically eager, to force the evaluation of side effects.  (Side effects
-are the only reason to execute such statements in the first place, and Perl
+are the only reason to execute such statements in the first place, and Raku
 will, in fact, warn you if you do something that is "useless" in sink
 context.)  A loop in sink context not only evaluates itself eagerly, but can
 optimize away the production of any values from the loop.
@@ -729,7 +729,7 @@ The C<given> construct is not considered a loop, and just returns normally.
 
 Although a bare block occurring as a single statement is no longer a do-once
 loop, as with loops when used in a statement list, it still executes
-immediately as in Perl 5, as if it were immediately dereferenced with a
+immediately as in Perl, as if it were immediately dereferenced with a
 C<.()> postfix, so within such a block C<CALLER::> refers to the dynamic
 scope associated with the lexical scope surrounding the block.
 
@@ -811,7 +811,7 @@ label syntax, such as .gather and .take methods on some identity object.)]
 If you take multiple items in a comma list (since it is, after all, a list
 operator), they will be wrapped up in a C<List> object for return as the
 next argument.  No additional context is applied by the C<take> operator,
-since all context is lazy in Perl 6.  The flattening or slicing of any such
+since all context is lazy in Raku.  The flattening or slicing of any such
 returned list will be dependent on how the C<gather>'s return iterator is
 iterated (with C<.get> vs C<.getarg>).
 
@@ -875,7 +875,7 @@ statement as in the examples above.
 The C<take> operation may be defined internally using resumable control
 exceptions, or dynamic variables, or pigeons carrying clay tablets.  The
 choice any particular implementation makes is specifically I<not> part of
-the definition of Perl 6, and you should not rely on it in portable code.
+the definition of Raku, and you should not rely on it in portable code.
 
 =head2 Other C<do>-like forms
 X<do>
@@ -887,7 +887,7 @@ without necessarily establishing a lexical scope.  (You can always establish
 a lexical scope explicitly by using the block form of argument.)  As
 statement introducers, all these keywords must be followed by whitespace.
 (You can say something like C<try({...})>, but then you are calling the
-C<try()> function using function call syntax instead, and since Perl does
+C<try()> function using function call syntax instead, and since Raku does
 not supply such a function, it will be assumed to be a user-defined
 function.) For purposes of flow control, none of these forms are considered
 loops, but they may easily be applied to a normal loop.
@@ -1031,10 +1031,10 @@ This is particularly useful for list comprehensions:
 =head1 Exception handlers
 X<CATCH>
 
-Unlike many other languages, Perl 6 specifies exception handlers by placing
+Unlike many other languages, Raku specifies exception handlers by placing
 a C<CATCH> block I<within> that block that is having its exceptions handled.
 
-The Perl 6 equivalent to Perl 5's C<eval {...}> is C<try {...}>.  (Perl 6's
+The Raku equivalent to Perl's C<eval {...}> is C<try {...}>.  (Raku's
 C<EVAL> function only evaluates strings, not blocks, and does not catch
 exceptions.) A C<try> block by default has a C<CATCH> block that handles all
 fatal exceptions by ignoring them.  If you define a C<CATCH> block within
@@ -1229,18 +1229,18 @@ be controlled.  In other words, it first tries this form:
 
 If there is no such lexically scoped outer loop in the current subroutine,
 then a fallback search is made outward through the dynamic scopes in the
-same way Perl 5 does.  (The difference between Perl 5 and Perl 6 in this
-respect arises only because Perl 5 didn't have user-defined control
+same way Perl does.  (The difference between Perl and Raku in this
+respect arises only because Perl didn't have user-defined control
 structures, hence the sub's lexical scope was I<always> the innermost
 dynamic scope, so the preference to the lexical scope in the current sub was
-implicit.  For Perl 6 we have to make this preference for lexotic behavior
+implicit.  For Raku we have to make this preference for lexotic behavior
 explicit.)
 
-Warnings are produced in Perl 6 by throwing a resumable control exception to
+Warnings are produced in Raku by throwing a resumable control exception to
 the outermost scope, which by default prints the warning and resumes the
 exception by extracting a resume continuation from the exception, which must
 be supplied by the C<warn()> function (or equivalent).  Exceptions are not
-resumable in Perl 6 unless the exception object does the C<Resumable> role.
+resumable in Raku unless the exception object does the C<Resumable> role.
 (Note that fatal exception types can do the C<Resumable> role even if thrown
 via C<fail()>--when uncaught they just hit the outermost fatal handler
 instead of the outermost warning handler, so some inner scope has to
@@ -1275,11 +1275,11 @@ failsoft semantics.
 =head1 The goto statement
 X<goto>
 
-In addition to C<next>, C<last>, and C<redo>, Perl 6 also supports C<goto>.
+In addition to C<next>, C<last>, and C<redo>, Raku also supports C<goto>.
 As with ordinary loop controls, the label is searched for first lexically
 within the current subroutine, then dynamically outside of it.  Unlike with
 loop controls, however, scanning a scope includes a scan of any lexical
-scopes included within the current candidate scope.  As in Perl 5, it is
+scopes included within the current candidate scope.  As in Perl, it is
 possible to C<goto> into a lexical scope, but only for lexical scopes that
 require no special initialization of parameters.  (Initialization of
 ordinary variables does not count--presumably the presence of a label will
@@ -1293,14 +1293,14 @@ for a bare block, so that doesn't fall under the prohibition on bypassing
 formal binding.)
 
 Because it is possible to go to a label that is after the operation, and
-because Perl 6 does one-pass parsing, any C<goto> to a label that has not
+because Raku does one-pass parsing, any C<goto> to a label that has not
 been yet declared (or is declared outside the outward lexical scope of the
 C<goto>) must enclose the label in quotes.
 
 =head1 Exceptions
 
-As in Perl 5, many built-in functions simply return an undefined value when
-you ask for a value out of range, or the function fails somehow.  Perl 6 has
+As in Perl, many built-in functions simply return an undefined value when
+you ask for a value out of range, or the function fails somehow.  Raku has
 C<Failure> objects, known as "unthrown exceptions" (though really a
 C<Failure> merely contains an unthrown exception), which know whether they
 have been handled or not.  C<$!> is a convenient link to the last failure,
@@ -1345,7 +1345,7 @@ You can cause built-ins to automatically throw exceptions on failure using
 
 The C<fail> function responds to the caller's C<use fatal> state.  It either
 returns an unthrown exception, or throws the exception.  Before you get too
-happy about this pragma, note that Perl 6 contains various parallel
+happy about this pragma, note that Raku contains various parallel
 processing primitives that will tend to get blown up prematurely by thrown
 exceptions.  Unthrown exceptions are meant to provide a failsoft mechanism
 in which failures can be treated as data and dealt with one by one, without
@@ -1616,7 +1616,7 @@ parentheses aren't necessary around C<EXPR> because the whitespace between
 C<EXPR> and the block forces the block to be considered a block rather than
 a subscript, provided the block occurs where an infix operator would be
 expected.  This works for all control structures, not just the new ones in
-Perl 6.  A top-level bare block is always considered a statement block if
+Raku.  A top-level bare block is always considered a statement block if
 there's a term and a space before it:
 
     if $foo { ... }
@@ -1771,17 +1771,17 @@ okay.
 
 In the absence of error exception propagation, a successful exit is one that
 returns a defined value or list.  (A defined list may contain undefined
-values.) So any Perl 6 function can say
+values.) So any Raku function can say
 
     fail "message";
 
 and not care about whether the function is being called in item or list
 context.  To return an explicit scalar undef, you can always say
 
-    return Mu;          # like "return undef" in Perl 5
+    return Mu;          # like "return undef" in Perl
 
 Then in list context, you're returning a list of length 1, which is defined
-(much like in Perl 5).  But generally you should be using C<fail> in such a
+(much like in Perl).  But generally you should be using C<fail> in such a
 case to return an exception object.  In any case, returning an unthrown
 exception is considered failure from the standpoint of C<let>.  Backtracking
 over a closure in a regex is also considered failure of the closure, which
@@ -1791,7 +1791,7 @@ regex.)
 
 =head1 When is a closure not a closure
 
-Everything is conceptually a closure in Perl 6, but the optimizer is free to
+Everything is conceptually a closure in Raku, but the optimizer is free to
 turn unreferenced closures into mere blocks of code.  It is also free to
 turn referenced closures into mere anonymous subroutines if the block does
 not refer to any external lexicals that should themselves be cloned.  (When
@@ -1832,7 +1832,7 @@ package declaration share the same set of compile-time declared functions,
 however, the runtime instances can have different lexical environments as
 described in the preceding paragraph.  If multiple conflicting definitions
 of a sub exist for the same compile-time package, an error condition exists
-and behavior is not specified for Perl 6.0.
+and behavior is not specified for Raku.
 
 Methods in classes behave functionally like package subroutines, and have
 the same binding behavior if the classes are cloned.  Note that a class

--- a/S05-regex.pod
+++ b/S05-regex.pod
@@ -28,9 +28,9 @@ the terms I<rule> and I<token> are generally preferred over I<regex>.
 
 =head1 Overview
 
-In essence, Perl 6 natively implements Parsing Expression Grammars (PEGs)
+In essence, Raku natively implements Parsing Expression Grammars (PEGs)
 as an extension of regular expression notation.  PEGs require that you
-provide a "pecking order" for ambiguous parses.  Perl 6's pecking order
+provide a "pecking order" for ambiguous parses.  Raku's pecking order
 is determined by a multi-level tie-breaking test:
 
     1) Most-derived only/proto hides less-derived of the same name
@@ -64,7 +64,7 @@ backtracks, the next best rule is chosen.  That is, the pecking order
 determines a candidate list; just because one candidate is chosen does not
 mean the rest are thrown away.  They may, however, be explicitly thrown away
 by an appropriate backtracking control (sometimes called a "cut" operator,
-but Perl 6 has several of them, depending on how much you want to cut).
+but Raku has several of them, depending on how much you want to cut).
 
 Also, any rule chosen to execute under #1 may choose to delegate to its ancestors;
 PEG backtracking has no control over this.
@@ -77,11 +77,11 @@ most recent match is through this variable, even when
 it doesn't look like it.  The individual capture variables (such as C<$0>,
 C<$1>, etc.) are just elements of C<$/>.
 
-By the way, unlike in Perl 5, the numbered capture variables now
+By the way, unlike in Perl, the numbered capture variables now
 start at C<$0> instead of C<$1>.  See below.
 
-In order to detect accidental use of Perl 5's unrelated C<$/>
-variable, Perl 6's C<$/> variable may not be assigned to directly.
+In order to detect accidental use of Perl's unrelated C<$/>
+variable, Raku's C<$/> variable may not be assigned to directly.
 
     $/ = $x;   # "Unsupported use of $/ variable as input record separator"
     $/ := $x;  # OK, binding
@@ -90,7 +90,7 @@ variable, Perl 6's C<$/> variable may not be assigned to directly.
 
 =head1 Unchanged syntactic features
 
-The following regex features use the same syntax as in Perl 5:
+The following regex features use the same syntax as in Perl:
 
 =over
 
@@ -120,12 +120,12 @@ While the syntax of C<|> does not change, the default semantics do
 change slightly.  We are attempting to concoct a pleasing mixture
 of declarative and procedural matching so that we can have the
 best of both.  In short, you need not write your own tokener for
-a grammar because Perl will write one for you.  See the section
+a grammar because Raku will write one for you.  See the section
 below on "Longest-token matching".
 
 =head1 Simplified lexical parsing of patterns
 
-Unlike traditional regular expressions, Perl 6 does not require
+Unlike traditional regular expressions, Raku does not require
 you to memorize an arbitrary list of metacharacters.  Instead it
 classifies characters by a simple rule.  All glyphs (graphemes)
 whose base characters are either the underscore (C<_>) or have
@@ -138,7 +138,7 @@ but any immediately following alphanumeric character is not).
 All other glyphs--including whitespace--are exactly the opposite:
 they are always considered metasyntactic (i.e. non-self-matching) and
 must be escaped or quoted to make them literal.  As is traditional,
-they may be individually escaped with C<\>, but in Perl 6 they may
+they may be individually escaped with C<\>, but in Raku they may
 be also quoted as follows.
 
 Sequences of one or more glyphs of either type (i.e. any glyphs at all)
@@ -168,7 +168,7 @@ escaped), non-identifier glyphs are metasyntactic (or literal when
 escaped), and single quotes make everything inside them literal.
 
 Note, however, that not all non-identifier glyphs are currently
-meaningful as metasyntax in Perl 6 regexes (e.g. C<\1> C<\_> C<->
+meaningful as metasyntax in Raku regexes (e.g. C<\1> C<\_> C<->
 C<!>). It is more accurate to say that all unescaped non-identifier
 glyphs are I<potential> metasyntax, and reserved for future use.
 If you use such a sequence, a helpful compile-time error is issued
@@ -319,9 +319,9 @@ the specified string position:
      m:pos($p)/ pattern /  # match at position $p
 
 If the argument is omitted, it defaults to C<($/ ?? $/.to !! 0)>.  (Unlike in
-Perl 5, the string itself has no clue where its last match ended.)
+Perl, the string itself has no clue where its last match ended.)
 All subrule matches are implicitly passed their starting position.
-Likewise, the pattern you supply to a Perl macro's C<is parsed>
+Likewise, the pattern you supply to a Raku macro's C<is parsed>
 trait has an implicit C<:p> modifier.
 
 Note that
@@ -492,13 +492,13 @@ which language's rules to use for this match.]
 
 =item *
 
-The new C<:Perl5>/C<:P5> modifier allows Perl 5 regex syntax to be
+The new C<:Perl5>/C<:P5> modifier allows Perl regex syntax to be
 used instead.  (It does not go so far as to allow you to put your
 modifiers at the end.)  For instance,
 
      m:P5/(?mi)^(?:[a-z]|\d){1,2}(?=\s)/
 
-is equivalent to the Perl 6 syntax:
+is equivalent to the Raku syntax:
 
     m/ :i ^^ [ <[a..z]> || \d ] ** 1..2 <?before \s> /
 
@@ -663,10 +663,10 @@ or you'll end up with:
 
 Any grammar regex is really just a kind of method, and you may
 declare variables in such a routine using a colon followed by any
-scope declarator parsed by the Perl 6 grammar, including C<my>,
+scope declarator parsed by the Raku grammar, including C<my>,
 C<our>, C<state>, and C<constant>.  (As quasi declarators, C<temp>
 and C<let> are also recognized.)  A single statement (up through
-a terminating semicolon or line-final closing brace) is parsed as normal Perl 6 code:
+a terminating semicolon or line-final closing brace) is parsed as normal Raku code:
 
     token prove-nondeterministic-parsing {
         :my $threshold = rand;
@@ -856,7 +856,7 @@ use extra brackets:
 
 The precedence of C<~~> and C<!~~> fits in between the junctional and
 sequential versions of the logical operators just as it does in normal
-Perl expressions (see S03).  Hence
+Raku expressions (see S03).  Hence
 
     <ident> !~~ 'moose' | 'squirrel'
 
@@ -957,7 +957,7 @@ within a regex establishes its own lexical scope.
 
 =item *
 
-You can call Perl code as part of a regex match by using a closure.
+You can call Raku code as part of a regex match by using a closure.
 Embedded code does not usually affect the match--it is only used
 for side-effects:
 
@@ -1043,7 +1043,7 @@ It is illegal to return a list, so this easy mistake fails:
 The closure form is always considered procedural, so the item it is
 modifying is never considered part of the longest token.
 
-For backwards compatibility with previous versions of Perl 6, if the token
+For backwards compatibility with previous versions of Raku, if the token
 following ** is not a closure or literal integer, it is interpreted as +%
 with a warning:
 
@@ -1091,7 +1091,7 @@ Any quantifier may be so modified:
 The C<%> modifier may only be used on a quantifier; any attempt
 to use it on a bare term will result in a parse error (to minimize
 possible confusion with any hash notations we choose to support in
-Perl 6 regexes).
+Raku regexes).
 
 A successful match of a C<%> construct generally ends "in the middle" at the C<%>,
 that is, after the initial item but before the next separator.
@@ -1197,7 +1197,7 @@ to put space on both sides of the C<*>:
 =item *
 
 C<< <...> >> are now extensible metasyntax delimiters or I<assertions>
-(i.e. they replace Perl 5's crufty C<(?...)> syntax).
+(i.e. they replace Perl's crufty C<(?...)> syntax).
 
 =back
 
@@ -1207,7 +1207,7 @@ C<< <...> >> are now extensible metasyntax delimiters or I<assertions>
 
 =item *
 
-In Perl 6 regexes, variables don't interpolate.
+In Raku regexes, variables don't interpolate.
 
 =item *
 
@@ -1218,11 +1218,11 @@ how to handle them (more on that below).
 
 The default way in which the engine handles a string scalar is to match it
 as a C<< "..." >> literal (i.e. it does not treat the interpolated string
-as a subpattern).  In other words, a Perl 6:
+as a subpattern).  In other words, a Raku:
 
      / $var /
 
-is like a Perl 5:
+is like a Perl:
 
      / \Q$var\E /
 
@@ -1338,7 +1338,7 @@ you can write:
 
 as long as you're careful to put a space after the initial angle so that
 it won't be interpreted as a subrule.  With the space it is parsed
-like angle quotes in ordinary Perl 6 and treated as a literal array value.
+like angle quotes in ordinary Raku and treated as a literal array value.
 
 =item *
 
@@ -1490,7 +1490,7 @@ To pass a regex with leading whitespace you must use the parenthesized form.
 
 If the first character is a colon followed by whitespace, the rest
 of the text is taken as a list of arguments to the method, just as
-in ordinary Perl syntax.  So these mean the same thing:
+in ordinary Raku syntax.  So these mean the same thing:
 
     <foo('foo', $bar, 42)>
     <foo: 'foo', $bar, 42>
@@ -2028,7 +2028,7 @@ These tokens are considered declarative.
 
 A C<«> or C<<< << >>> token indicates a left word boundary.  A C<»> or
 C<<< >> >>> token indicates a right word boundary.  (As separate tokens,
-these need not be balanced.)  Perl 5's C<\b> is replaced by a C<< <|w> >>
+these need not be balanced.)  Perl's C<\b> is replaced by a C<< <|w> >>
 "word boundary" assertion, while C<\B> becomes C<< <!|w> >>.  (None of
 these are dependent on the definition of C<< <.ws> >>, but only on the C<\w>
 definition of "word" characters.  Non-space mark characters are ignored in
@@ -2301,11 +2301,11 @@ available as backslash sequences:
 
 =item *
 
-The Perl 5 C<qr/pattern/> regex constructor is gone.
+The Perl C<qr/pattern/> regex constructor is gone.
 
 =item *
 
-The Perl 6 equivalents are:
+The Raku equivalents are:
 
      regex { pattern }    # always takes {...} as delimiters
      rx    / pattern /    # can take (almost) any chars as delimiters
@@ -2318,7 +2318,7 @@ but only if you interpose whitespace:
      rx ( pattern )      # okay
      rx( 1,2,3 )         # tries to call rx function
 
-(This is true for all quotelike constructs in Perl 6.)
+(This is true for all quotelike constructs in Raku.)
 
 The C<rx> form may be used directly as a pattern anywhere a normal C<//> match can.
 The C<regex> form is really a method definition, and must be used in such a way that
@@ -2351,7 +2351,7 @@ longer an interpolating quote-like operator.  C<rx> is short for I<regex>,
 =item *
 
 As the syntax indicates, it is now more closely analogous to a C<sub {...}>
-constructor.  In fact, that analogy runs I<very> deep in Perl 6.
+constructor.  In fact, that analogy runs I<very> deep in Raku.
 
 =item *
 
@@ -2442,7 +2442,7 @@ A C<rule> is really short for:
 
 =item *
 
-The Perl 5 C<?...?> syntax (I<succeed once>) was rarely used and can be
+The Perl C<?...?> syntax (I<succeed once>) was rarely used and can be
 now emulated more cleanly with a state variable:
 
     $result = do { state $x ||= m/ pattern /; }    # only matches first time
@@ -2475,15 +2475,15 @@ To force the preceding atom to do frugal backtracking (also sometimes
 known as "eager matching" or "minimal matching"),
 append a C<:?> or C<?> to the atom.  If the preceding token is
 a quantifier, the C<:> may be omitted, so C<*?> works just as
-in Perl 5.
+in Perl.
 
 =item *
 
 To force the preceding atom to do greedy backtracking in a
 spot that would default otherwise, append a C<:!> to the atom.
 If the preceding token is a quantifier, the C<:> may be omitted.
-(Perl 5 has no corresponding construct because backtracking always
-defaults to greedy in Perl 5.)
+(Perl has no corresponding construct because backtracking always
+defaults to greedy in Perl.)
 
 =item *
 
@@ -2753,7 +2753,7 @@ tend to parse text in their heads, so the computer ought to try to do
 the same.  And parsing with LTM is all about how the computer decides
 which alternative of a set of alternatives is going to match.
 
-Instead of representing temporal alternation as it does in Perl 5, in Perl 6 C<|> represents
+Instead of representing temporal alternation as it does in Perl, in Raku C<|> represents
 logical alternation with declarative longest-token semantics.  (You may
 now use C<||> to indicate the old temporal alternation.  That is, C<|>
 and C<||> now work within regex syntax much the same as they do outside
@@ -2766,7 +2766,7 @@ efficiently by processing rules in parallel rather than one after
 another, at least up to a point.  If you look at something like a
 yacc grammar, you find a lot of pattern/action declarations where the
 patterns are considered in parallel, and eventually the grammar decides
-which action to fire off.  While the default Perl view of parsing is
+which action to fire off.  While the default Raku view of parsing is
 essentially top-down (perhaps with a bottom-up "middle layer" to handle
 operator precedence), it is extremely useful for user understanding
 if at least the token processing proceeds deterministically.  So for
@@ -2774,10 +2774,10 @@ regex matching purposes we define token patterns as those patterns
 that can be matched without potential side effects or self-reference.
 (Since whitespace often has side effects at line transitions, it
 is usually excluded from such patterns, give or take a little
-lookahead.)  Basically, Perl automatically derives a lexer
+lookahead.)  Basically, Raku automatically derives a lexer
 from the grammar without you having to write one yourself.
 
-To that end, every regex in Perl 6 is required to be able to
+To that end, every regex in Raku is required to be able to
 distinguish its "pure" patterns from its actions, and return its
 list of initial token patterns (transitively including the token
 patterns of any subrule called by the "pure" part of that regex, but
@@ -2800,7 +2800,7 @@ are defined in more than one file, the order is undefined, and an explicit
 assertion must be used to force failure if the wrong one is tried first.)
 
 This longest token prefix corresponds roughly to the notion of "token"
-in other parsing systems that use a lexer, but in the case of Perl
+in other parsing systems that use a lexer, but in the case of Raku
 this is largely an epiphenomenon derived automatically from the grammar
 definition.  However, despite being automatically calculated, the set of
 tokens can be modified by the user; various
@@ -2993,7 +2993,7 @@ type.  Using the C<make>/C<.made> mechanism, it is convenient to build up an
 abstract syntax tree of arbitrary node types.
 
 However, the C<make> function is not limited to be used for storing AST
-nodes and building abstract syntax trees only.  This is just a specific Perl 6
+nodes and building abstract syntax trees only.  This is just a specific Raku
 internal use of this functionality.  Nor does the C<make> function impose any
 item or list context onto its argument, so if you say something ambiguously
 listy like
@@ -3273,7 +3273,7 @@ pushed onto the array inside the C<Match> object for the entire regex
 
 =item *
 
-As a result of these semantics, capturing parentheses in Perl 6 are
+As a result of these semantics, capturing parentheses in Raku are
 hierarchical, not linear (see L<Nested subpattern captures>).
 
 =back
@@ -3297,7 +3297,7 @@ is the same as:
 
 =item *
 
-Note that, in Perl 6, the numeric capture variables start from $0, not
+Note that, in Raku, the numeric capture variables start from $0, not
 $1, with the numbers corresponding to the element's index inside C<$/>.
 
 =item *
@@ -3329,9 +3329,9 @@ object, not to the array of C<$/>.
 
 =item *
 
-This behavior is quite different from Perl 5 semantics:
+This behavior is quite different from Perl semantics:
 
-      # Perl 5...
+      # Perl...
       #
       # $1---------------------  $4---------  $5------------------
       # |   $2---------------  | |          | | $6----  $7------  |
@@ -3341,9 +3341,9 @@ This behavior is quite different from Perl 5 semantics:
 
 =item *
 
-In Perl 6, nested parens produce properly nested captures:
+In Raku, nested parens produce properly nested captures:
 
-      # Perl 6...
+      # Raku...
       #
       # $0---------------------  $1---------  $2------------------
       # |   $0[0]------------  | |          | | $2[0]-  $2[1]---  |
@@ -3525,12 +3525,12 @@ C<|> or C<||> (but not after each C<&> or C<&&>). Hence:
 
 This means that if the second alternation matches, the list value of the match will
 contain C<('every', 'green', 'BEM', 'devours', 'faces')> rather than
-Perl 5's C<(undef, undef, undef, undef, undef, undef, 'every', 'green', 'BEM',
+Perl's C<(undef, undef, undef, undef, undef, undef, 'every', 'green', 'BEM',
 'devours', 'faces')>.
 
 =item *
 
-Note that it is still possible to mimic the monotonic Perl 5 capture
+Note that it is still possible to mimic the monotonic Perl capture
 indexing semantics.  See L<Numbered scalar aliasing> below for details.
 
 
@@ -3870,7 +3870,7 @@ value). That is:
 =item *
 
 This I<follow-on> behavior is particularly useful for reinstituting
-Perl 5 semantics for consecutive subpattern numbering in alternations:
+Perl semantics for consecutive subpattern numbering in alternations:
 
      $tune_up = rx/ ("don't") (ray) (me) (for) (solar tea), ("d'oh!")
                   | $6 = (every) (green) (BEM) (devours) (faces)
@@ -3879,10 +3879,10 @@ Perl 5 semantics for consecutive subpattern numbering in alternations:
 
 =item *
 
-It also provides an easy way in Perl 6 to reinstitute the unnested
-numbering semantics of nested Perl 5 subpatterns:
+It also provides an easy way in Raku to reinstitute the unnested
+numbering semantics of nested Perl subpatterns:
 
-      # Perl 5...
+      # Perl...
       #               $1
       #  _____________/\___________
       # |    $2        $3      $4  |
@@ -3891,7 +3891,7 @@ numbering semantics of nested Perl 5 subpatterns:
      m/ ( ( [A-E] ) (\d{3,6}) (X?) ) /x;
 
 
-      # Perl 6...
+      # Raku...
       #                $0
       #  ______________/\______________
       # |   $0[0]       $0[1]    $0[2] |
@@ -3900,7 +3900,7 @@ numbering semantics of nested Perl 5 subpatterns:
      m/ ( (<[A..E]>) (\d ** 3..6) (X?) ) /;
 
 
-      # Perl 6 simulating Perl 5...
+      # Raku simulating Perl...
       #                 $1
       #  _______________/\________________
       # |        $2          $3       $4  |
@@ -4273,7 +4273,7 @@ match is also available:
 
          for lol() -> $m {
              say "Match between $m.from() and $m.to()";
-             say 'Right on, dude!' if $m[0] eq 'Perl';
+             say 'Right on, dude!' if $m[0] eq 'Raku';
              say "Rocks like $m<rocks>";
          }
      }
@@ -4359,9 +4359,9 @@ C<line>, etc.
 
 =item *
 
-Perl 6 will come with at least one grammar predefined:
+Raku will come with at least one grammar predefined:
 
-     grammar STD {    # Perl's own standard grammar
+     grammar STD {    # Raku's own standard grammar
 
          rule prog { <statement>* }
 
@@ -4412,7 +4412,7 @@ Grammar objects are considered immutable, so
 every match returns a different match state, and multiple match states may
 exist simultaneously.  Each such match state is considered a hypothesis on
 how the pattern will eventually match.  A backtrackable choice in pattern
-matching may be easily represented in Perl 6 as a lazy list of match state
+matching may be easily represented in Raku 6 as a lazy list of match state
 cursors; backtracking consists of merely throwing away the front value of
 the list and continuing to match with the next value.  Hence, the management
 of these match cursors controls how backtracking works, and falls naturally
@@ -4472,7 +4472,7 @@ to the particular declarator in question:
     use token :foo;     # control token defaults
     use rule :foo;      # control rule defaults
 
-(It is a general policy in Perl 6 that any pragma designed to influence
+(It is a general policy in Raku that any pragma designed to influence
 the surface behavior of a keyword is identical to the keyword itself, unless
 there is good reason to do otherwise.  On the other hand, pragmas designed
 to influence deep semantics should not be named identically, though of
@@ -4494,7 +4494,7 @@ Use the C<.=> form to do a translation in place:
 
      $str.=trans( %mapping.pairs );
 
-(Perl 6 does not support the C<y///> form, which was only in C<sed> because
+(Raku does not support the C<y///> form, which was only in C<sed> because
 they were running out of single letters.)
 
 =item *
@@ -4600,8 +4600,8 @@ Only non-bracket characters may be used for the "triple quote".  The
 right side is always evaluated as if it were a double-quoted string
 regardless of the quote chosen.
 
-As with Perl 5, a bracketing form is also supported, but unlike Perl 5,
-Perl 6 uses the brackets I<only> around the pattern.  The replacement
+As with Perl, a bracketing form is also supported, but unlike Perl,
+Raku uses the brackets I<only> around the pattern.  The replacement
 is then specified as if it were an ordinary item assignment, with ordinary
 quoting rules.  To pick your own quotes on the right just use one of the C<q>
 forms.  The substitution above is equivalent to:
@@ -4698,7 +4698,7 @@ the C<< <at($pos)> >> assertion to say that the current position
 is the same as the position object you supply.  You may set the
 current match position via the C<:c> and C<:p> modifiers.
 
-However, please remember that in Perl 6 string positions are generally
+However, please remember that in Raku string positions are generally
 I<not> integers, but objects that point to a particular place in
 the string regardless of whether you count by bytes or codepoints or
 graphemes.  If used with an integer, the C<at> assertion will assume
@@ -4798,7 +4798,7 @@ smartmatching:
 To provide implementational freedom, the C<$/> variable is not
 guaranteed to be defined until the pattern reaches a sequence
 point that requires it (such as completing the match, or calling an
-embedded closure, or even evaluating a submatch that requires a Perl
+embedded closure, or even evaluating a submatch that requires a Raku
 expression for its argument).  Within regex code, C<$/> is officially
 undefined, and references to C<$0> or other capture variables may
 be compiled to produce the current value without reference to C<$/>.
@@ -4812,7 +4812,7 @@ is of type C<Match>, while the match state is of a type derived from C<Cursor>.
 In any case this is all transparent to the user for simple matches;
 and outside of regex code (and inside closures within the regex)
 the C<$/> variable is guaranteed to represent the state of the match
-at that point.  That is, normal Perl code can always depend on C<<
+at that point.  That is, normal Raku code can always depend on C<<
 $<foo> >> meaning C<< $/<foo> >>, and C<$0> meaning C<$/[0]>, whether
 that code is embedded in a closure within the regex or outside the
 regex after the match completes.

--- a/S06-routines.pod
+++ b/S06-routines.pod
@@ -266,8 +266,8 @@ The return type may also be put inside the parentheses:
 
     sub NAME (PARAMS --> RETTYPE) {...}
 
-Unlike in Perl 5, named subroutines are considered expressions,
-so this is valid Perl 6:
+Unlike in Perl, named subroutines are considered expressions,
+so this is valid Raku:
 
     my @subs = (sub foo { ... }, sub bar { ... });
 
@@ -314,9 +314,9 @@ B<Trait> is the name for a compile-time (C<is>) property.
 See L<"Properties and traits">.
 
 
-=head2 Perl5ish subroutine declarations
+=head2 Perlish subroutine declarations
 
-You can declare a sub without parameter list, as in Perl 5:
+You can declare a sub without parameter list, as in Perl:
 
     sub foo {...}
 
@@ -330,13 +330,13 @@ This is equivalent to one of:
 depending on whether either or both of those variables are used in the body of the routine.
 
 Positional arguments implicitly come in via the C<@_> array, but
-unlike in Perl 5 they are C<readonly> aliases to actual arguments:
+unlike in Perl they are C<readonly> aliases to actual arguments:
 
     sub say { print qq{"@_[]"\n}; }   # args appear in @_
 
     sub cap { $_ = uc $_ for @_ }   # Error: elements of @_ are read-only
 
-Also unlike in Perl 5, Perl 6 has true named arguments, which come in
+Also unlike in Perl, Raku has true named arguments, which come in
 via C<%_> instead of C<@_>.
 
 If you need to modify the elements of C<@_> or C<%_>, declare the
@@ -362,7 +362,7 @@ simply fail if the signature cannot be bound.
 
 =head2 Blocks
 
-Raw blocks are also executable code structures in Perl 6.
+Raw blocks are also executable code structures in Raku.
 
 Every block defines an object of type C<Block> (which C<does Callable>), which may either be
 executed immediately or passed on as a C<Block> object.  How a block is
@@ -427,11 +427,11 @@ To predeclare a subroutine without actually defining it, use a "stub block":
 
     sub foo {...}     # Yes, those three dots are part of the actual syntax
 
-The old Perl 5 form:
+The old Perl form:
 
     sub foo;
 
-is a compile-time error in Perl 6 (because it would imply that the body of the
+is a compile-time error in Raku (because it would imply that the body of the
 subroutine extends from that statement to the end of the file, as C<class> and
 C<module> declarations do).  The only allowed use of the semicolon form is to
 declare a C<MAIN> sub--see L</Declaring a MAIN subroutine> below.  (And this
@@ -620,7 +620,7 @@ A null operator name does not define a null or whitespace operator, but
 a default matching subrule for that syntactic category, which is useful when
 there is no fixed string that can be recognized, such as tokens beginning
 with digits.  Such an operator I<must> supply an C<is parsed> trait.
-The Perl grammar uses a default subrule for the C<:1st>, C<:2nd>, C<:3rd>,
+The Raku grammar uses a default subrule for the C<:1st>, C<:2nd>, C<:3rd>,
 etc. regex modifiers, something like this:
 
     sub regex_mod_external:<> ($x) is parsed(token { \d+[st|nd|rd|th] }) {...}
@@ -636,7 +636,7 @@ non-standard syntax available to other scopes.
 
 =head1 Calling conventions
 
-In Perl 6 culture, we distinguish the terms I<parameter> and
+In Raku culture, we distinguish the terms I<parameter> and
 I<argument>; a parameter is the formal name that will attach to an
 incoming argument during the course of execution, while an argument
 is the actual value that will be bound to the formal parameter.
@@ -646,7 +646,7 @@ uses the terms "formal argument" and "actual argument" for these
 two concepts, but here we try to avoid using the term "argument"
 for formal parameters.)
 
-Various Perl 6 code objects (either routines or blocks) may be
+Various Raku code objects (either routines or blocks) may be
 declared with parameter lists, either explicitly by use of a signature
 declaration, or implicitly by use of placeholder variables within the body
 of code.  (Use of both for the same code block is not allowed.)
@@ -717,7 +717,7 @@ not Iterable (and therefore elimination of the container would not affect
 flattening behavior).
 
 Array and hash parameters are simply bound "as is". (Conjectural: future
-versions of Perl 6 may do static analysis and forbid assignments to array
+versions of Raku may do static analysis and forbid assignments to array
 and hash parameters that can be caught by it. This will, however, only
 happen with the appropriate "use" declaration to opt in to that language
 version.)
@@ -750,7 +750,7 @@ Also, C<$ro> may not be returned from an lvalue subroutine or method.
 
 Parameters may be required or optional. They may be passed by position,
 or by name. Individual parameters may confer an item or list context
-on their corresponding arguments, but unlike in Perl 5, this is decided
+on their corresponding arguments, but unlike in Perl, this is decided
 lazily at parameter binding time.
 
 Arguments destined for required positional parameters must come before
@@ -871,7 +871,7 @@ arguments with parentheses or quotes:
     push @array, 1, 2, (:a<b>);
     push @array, 1, 2, 'a' => 'b';
 
-Perl 6 allows multiple same-named arguments, and records the relative
+Raku allows multiple same-named arguments, and records the relative
 order of arguments with the same name.  When there are more than one
 argument, the C<@> sigil in the parameter list causes the arguments
 to be appended:
@@ -1152,7 +1152,7 @@ so you can refer to it within the body.
         # %flag has elements (flag => (a => 1)) and (data => [1,2,3])
         # @data has nothing
 
-[Conjecture: a future Perl 6 version will allow typed slurpy parameters, which
+[Conjecture: a future Raku version will allow typed slurpy parameters, which
 will validate the types of the passed arguments.]
 
 =head2 Slurpy block
@@ -1916,7 +1916,7 @@ Also, it is illegal to use placeholder variables in a block that already
 has a signature, because the autogenerated signature would conflict with that.
 Positional placeholder names consisting of a single uppercase letter are disallowed,
 not because we're mean, but because it helps us catch references to
-obsolete Perl 5 variables such as C<$^O>.
+obsolete Perl variables such as C<$^O>.
 
 The C<$_> variable functions as a placeholder in a block without any
 other placeholders or signature.  Any bare block without placeholders
@@ -1960,7 +1960,7 @@ the block.  Subsequent mentions of that variable may omit the twigil.
 Within an internal nested block the twigil I<must> be omitted, since
 it would wrongly attach to the inner block.
 
-Note that, unlike in Perl 5, C<@_> may not be used within an inner block to
+Note that, unlike in Perl, C<@_> may not be used within an inner block to
 refer to the outer block's arguments:
 
     sub say-or-print {
@@ -1983,7 +1983,7 @@ because this desugars to:
         }
     }
 
-Translators of Perl 5 will need to bear this in mind.
+Translators of Perl will need to bear this in mind.
 
 =head1 Properties and traits
 
@@ -3133,7 +3133,7 @@ A compile-time call to a macro before its definition is erroneous.
 
 =head2 Quasiquoting
 
-In aid of returning syntax tree, Perl provides a "quasiquoting"
+In aid of returning syntax tree, Raku provides a "quasiquoting"
 mechanism using the quote C<quasi>, followed by a block intended to
 represent an AST:
 
@@ -3207,7 +3207,7 @@ is probably to be construed as Bad Style:
 
 (Note to implementors: this must not be implemented by finding
 the final closing delimiter and preprocessing, or we'll violate our
-one-pass parsing rule.  Perl 6 parsing rules are parameterized to know
+one-pass parsing rule.  Raku parsing rules are parameterized to know
 their closing delimiter, so adding the opening delimiter should not
 be a hardship.  Alternately the opening delimiter can be deduced from
 the closing delimiter.  Writing a rule that looks for three opening
@@ -3343,7 +3343,7 @@ the current block was defined).
 
 =head2 Declaring a C<MAIN> subroutine
 
-Ordinarily a top-level Perl "script" just evaluates its anonymous
+Ordinarily a top-level Raku "script" just evaluates its anonymous
 mainline code and exits.  During the mainline code, the program's
 arguments are available in raw form from the C<@*ARGS> array.  At the end of
 the mainline code, however, a C<MAIN> subroutine will be called with
@@ -3403,7 +3403,7 @@ A C<proto> or C<multi> definition may not be written in semicolon form,
 nor may C<MAIN> subs within a module or class be written in semicolon form.  (A C<MAIN> routine
 is allowed in a module or class, but is not usually invoked unless
 the file is run directly (see a above).  This corresponds to the
-"unless caller" idiom of Perl 5.)  In general, you may have only one
+"unless caller" idiom of Perl.)  In general, you may have only one
 semicolon-style declaration that controls the whole file.
 
 If an attempted dispatch to C<MAIN> fails, the C<USAGE> routine is called.
@@ -3454,7 +3454,7 @@ as follows:
     :name='spacey value'       :name«'spacey value'»
     :name=val1,'val 2',etc     :name«val1 'val 2' etc»
 
-Exact Perl 6 forms are okay if quoted from shell processing:
+Exact Raku forms are okay if quoted from shell processing:
 
     ':name<value>'             :name<value>
     ':name(42)'                :name(42)

--- a/S07-lists.pod
+++ b/S07-lists.pod
@@ -13,7 +13,7 @@ Synopsis 7: Lists and Iteration
 
 =head1 Design Overview
 
-Perl 6 provides a wide array of list-related features, including eager, lazy,
+Raku provides a wide array of list-related features, including eager, lazy,
 and parallel evaluation of sequences of values, and arrays offering compact
 and multi-dimensional storage. Laziness in particular needs careful handling,
 so as to provide the power advanced users desire while not creating surprises
@@ -21,12 +21,12 @@ for typical language users who have the (reasonable) expectation that an
 assignment into an array will have immediate effect. Additionally, it is
 important to give the programmer control of when values will and won't be
 retained. Finally, all of this needs to be done in a way that provides
-the convenience that a Perl is expected to provide, while still having a
+the convenience that a Raku is expected to provide, while still having a
 model that can be understood through understanding a small number of rules.
 
 =head2 Sequences vs. Lists
 
-In Perl 6, we use the term "sequence" to refer to something that can, when
+In Raku, we use the term "sequence" to refer to something that can, when
 requested, produce a sequence of values. Of note, it can only be asked to
 produce them once. We use the term "list" to refer to things that hold (and
 so remember) values. There are various concrete types that represent various
@@ -40,12 +40,12 @@ kinds of list and sequence with different semantics:
 
 =head2 The single argument rule
 
-The C<@> sigil in Perl indicates "these", while C<$> indicates "the". This
+The C<@> sigil in Raku indicates "these", while C<$> indicates "the". This
 kind of plural/single distinction shows up in various places in the language,
-and much convenience in Perl comes from it. Flattening is the idea that an
+and much convenience in Raku comes from it. Flattening is the idea that an
 C<@>-like thing will, in certain contexts, have its values automatically
 incorporated into the surrounding list. Traditionally this has been a source
-of both great power and great confusion in Perl. Perl 6 has been through a
+of both great power and great confusion in Perl. Raku has been through a
 number of models relating to flattening during its evolution, before settling
 on a straightforward one known as the "single argument rule".
 
@@ -63,7 +63,7 @@ treated as a single argument to the C<for> loop, thus the name of the rule.
 
 The first two are equivalent because parentheses do not actually construct a
 list, but only group. It is the C<< infix:<,> >> operator that forms a list.
-The third also performs three iterations, since in Perl 6 C<[...]> constructs
+The third also performs three iterations, since in Raku C<[...]> constructs
 an C<Array> but does not wrap it into a C<Scalar> container. The fourth will
 do two iterations, since the argument is a list of two things; that they both
 happen to have the C<@>-sigil does not, alone, lead to any kind of flattening.
@@ -301,9 +301,9 @@ method on the argument and bind the result of that instead.
 
 =head2 Iterable
 
-Both C<Seq> and C<List>, along with various other types in Perl 6, do the
+Both C<Seq> and C<List>, along with various other types in Raku, do the
 C<Iterable> role. The primary purpose of this role is to promise that an
-C<iterator> method is available. The average Perl 6 user will rarely need
+C<iterator> method is available. The average Raku user will rarely need
 to care about the C<iterator> method and what it returns.
 
 The secondary purpose of C<Iterable> is to mark out things that will

--- a/S08-capture.pod
+++ b/S08-capture.pod
@@ -17,7 +17,7 @@ Synopsis 8: Capture and Argument Lists
 Unlike most programming languages, the data structure that is used to
 send the parameters into a routine invocation (be it a method or a
 sub) is exposed to the language as a built-in type like any
-other. This represents a very important aspect of the Perl 6 runtime
+other. This represents a very important aspect of the Raku runtime
 requirements.
 
 Additionally to the fact that this data structure is visible in the
@@ -32,7 +32,7 @@ purposes, but it should allow the use of foreign types when invoking a
 routine, as long as the object says true to C<.^does(Capture)>.
 
 Captures and argument lists are also the basis for the multidimensionality of
-lists in Perl 6. Unlike Perl 5, no flattening happens unless it's
+lists in Raku. Unlike Perl, no flattening happens unless it's
 explicitly required by the user, which is done by enforcing the list
 context. If you use the item context the dimensionality should be
 preserved.
@@ -44,9 +44,9 @@ List is kept as-is while they are manipulated in the code. This is
 useful to avoid unwanted flattening as well as avoiding the DWIMmy
 features that might change the capture's behavior.
 
-This is the main point of why Captures replace Perl 5
+This is the main point of why Captures replace Perl
 references; they allow you to send data untouched from one place to
-another. The second reason is that as in Perl 6 everything is an
+another. The second reason is that as in Raku everything is an
 object, there isn't really "pass-by-value" anymore, you're always
 sending a reference, Captures simply carry other objects
 without enforcing any context on them.
@@ -103,7 +103,7 @@ information about the position of named arguments.
 =head1 Multidimensionality
 
 Probably the most important task of Lists and Captures is to
-implement the multidimensionality of lists in Perl 6, this means that
+implement the multidimensionality of lists in Raku, this means that
 the barrier used to detect the dimensionality of the data structures
 by the operators is whatever the item inside it implements List or
 Capture. For instance:
@@ -198,11 +198,11 @@ Capture context is able to preserve the values as-is,
 in a way that you can later apply any context and have the same result
 as if the context was applied immediately.
 
-Context deferral is actually the reason why Perl 6 no longer supports
+Context deferral is actually the reason why Raku no longer supports
 the "wantarray" operator, nor does it provide any substitute. The way
 you should implement wantarray-like behavior is by properly overriding
 the coercion for each context. The Contextual::Return module is an
-implementation of that concept in Perl 5.
+implementation of that concept in Perl.
 
 [ The capture sigil does not exist, though left in this document for the time
 being pending a suitable replacement mechanism to handle context deferral.]

--- a/S09-data.pod
+++ b/S09-data.pod
@@ -15,9 +15,9 @@ Synopsis 9: Data Structures
 =head1 Overview
 
 This synopsis summarizes the non-existent Apocalypse 9, which
-discussed in detail the design of Perl 6 data structures.  It was
-primarily a discussion of how the existing features of Perl 6 combine
-to make it easier for the PDL folks to write numeric Perl.
+discussed in detail the design of Raku data structures.  It was
+primarily a discussion of how the existing features of Raku combine
+to make it easier for the PDL folks to write numeric Raku.
 
 =head1 Lazy lists
 
@@ -91,7 +91,7 @@ if both types used are native types, the resulting type is considered a native t
 
 You are, of course, free to use macros or type declarations to
 associate additional names, such as "short" or "single".  These are
-not provided by default.  An implementation of Perl is not required
+not provided by default.  An implementation of Raku is not required
 to support 64-bit integer types or 128-bit floating-point types unless
 the underlying architecture supports them.  16-bit floating-point is
 also considered optional in this sense.
@@ -267,7 +267,7 @@ aren't so small they produce negative indices.
 
 Another use might be to map positive numbers to even slots and negative
 numbers to odd slots, so you get indices that are symmetric around 0
-(though Perl is not going to track the max-used even and odd slots
+(though Raku is not going to track the max-used even and odd slots
 for you when the data isn't symmetric).
 
 =head1 Typed arrays
@@ -301,16 +301,16 @@ In declarations of the form:
     my complex128 @longdoublecomplex;
     my Array @ragged2d;
 
-the presence of a low-level type tells Perl that it is free to
+the presence of a low-level type tells Raku that it is free to
 implement the array with "compact storage", that is, with a chunk
 of memory containing contiguous (or as contiguous as practical)
 elements of the specified type without any fancy object boxing that
-typically applies to undifferentiated scalars.  (Perl tries really
+typically applies to undifferentiated scalars.  (Raku tries really
 hard to make these elements look like objects when you treat them
 like objects--this is called autoboxing.)
 
 Unless explicitly declared to be of fixed size, such
-arrays are autoextending just like ordinary Perl arrays
+arrays are autoextending just like ordinary Raku arrays
 (at the price of occasionally copying the block of data to another
 memory location, or using a tree structure).
 
@@ -341,7 +341,7 @@ of any declaration to the contrary.  For interfacing to C pointer
 types, any buffer type may be used for its memory pointer; note,
 however, that the buffer knows its length, while in C that length
 typically must be passed as a separate argument, so the C interfacing
-code needs to support this whenever possible, lest Perl inherit all
+code needs to support this whenever possible, lest Raku inherit all
 the buffer overrun bugs bequeathed on us by C.  Random C pointers
 should never be converted to buffers unless the length is also known.
 (Any call to strlen() should generally be considered a security hole.)
@@ -355,7 +355,7 @@ higher-level abstraction into some buffer type.)
 
 =head1 Multidimensional arrays
 
-Perl 6 arrays are not restricted to being one-dimensional (that's simply
+Raku arrays are not restricted to being one-dimensional (that's simply
 the default). To declare a multidimensional array, you specify it with a
 semicolon-separated list of dimension lengths:
 
@@ -679,7 +679,7 @@ except in the case of range truncation described earlier.)
 Negative subscripts are never allowed for standard subscripts unless
 the subscript is declared modular.
 
-The Perl 6 semantics avoids indexing discontinuities (a source of subtle
+The Raku semantics avoids indexing discontinuities (a source of subtle
 runtime errors), and provides ordinal access in both directions at both
 ends of the array.
 
@@ -878,12 +878,12 @@ The zero-dimensional slice:
     @x[]
 
 is assumed to want everything, not nothing.  It's particularly handy
-because Perl 6 (unlike Perl 5) won't interpolate a bare array without brackets:
+because Raku (unlike Perl) won't interpolate a bare array without brackets:
 
     @x = (1,2,3);
     say "@x = @x[]";    # prints @x = 1 2 3
 
-Lists are lazy in Perl 6, and the slice lists are no exception.
+Lists are lazy in Raku, and the slice lists are no exception.
 In particular, list generators are not flattened until they
 need to be, if ever.  So a PDL implementation is free to steal the
 values from these generators and "piddle" around with them:
@@ -898,7 +898,7 @@ values from these generators and "piddle" around with them:
 
 =head1 PDL signatures
 
-To rewrite a Perl 5 PDL definition like this:
+To rewrite a Perl PDL definition like this:
 
        pp_def(
             'inner',
@@ -943,8 +943,8 @@ come back into the signature via C<where> constraints on the types.
 This would presumably make multimethod dispatch possible on similarly
 typed arrays with differing constraints.
 
-(The special destruction problems of Perl 5's PDL should go away with
-Perl 6's GC approach, as long as PDL's objects are registered with the
+(The special destruction problems of Perl's PDL should go away with
+Raku's GC approach, as long as PDL's objects are registered with the
 run-time system correctly.)
 
 =head1 Autothreading types
@@ -1048,7 +1048,7 @@ are subject to change over time; it is therefore erroneous to pass
 junctions to any control construct that is not implemented via as a
 normal single dispatch or function call.  In particular, threading junctions
 through conditionals correctly could involve continuations, which
-are almost but not quite mandated in Perl 6.0.0.  Alternately, we
+are almost but not quite mandated in Raku.  Alternately, we
 may decide that boolean contexts always collapse the junction by
 default, and the exact value that allowed the collapse to "true"
 is not available.  A variant of that is to say that if you want
@@ -1232,14 +1232,14 @@ Any mention of an expression within a Capture (that is, an argument list)
 delays the autovivification decision to binding time.  (Binding to a
 raw parameter defers the decision even further.)
 
-This is as opposed to Perl 5, where autovivification could happen
+This is as opposed to Perl, where autovivification could happen
 unintentionally, even when the code looks like a non-destructive test:
 
-    # This is Perl 5 code
+    # This is Perl code
     my %hash;
     exists $hash{foo}{bar}; # creates $hash{foo} as an empty hash reference
 
-In Perl 6 these read-only operations are indeed non-destructive:
+In Raku these read-only operations are indeed non-destructive:
 
     my %hash;
     %hash<foo><bar> :exists; # %hash is still empty

--- a/S10-packages.pod
+++ b/S10-packages.pod
@@ -19,13 +19,13 @@ despite never having been written.
 
 =head1 Packages
 
-As in Perl 5, packages are the basis of modules and classes.  Unlike in
-Perl 5, modules and classes are declared with distinct keywords,
+As in Perl, packages are the basis of modules and classes.  Unlike in
+Perl, modules and classes are declared with distinct keywords,
 but they're still just packages with extra behaviors.  Likewise every
 typename has an associated package namespace, even if unused.
 
 An ordinary package is declared with the C<package> keyword.  Unlike in
-earlier versions of Perl 5, in Perl 6 it can only be used with a block:
+earlier versions of Perl, in Raku it can only be used with a block:
 
     package Bar {...}   # block is in package Bar
 
@@ -34,20 +34,20 @@ named subroutine declarations.
 
 As a special exception, if a braceless C<package> declaration occurs
 as the first executable statement in a file, then it's taken to mean that the rest of
-the file is Perl 5 code.
+the file is Perl code.
 
-    package Foo;        # the entire file is Perl 5
+    package Foo;        # the entire file is Perl
     ...
 
-This form is illegal in a Perl 6 file.  If you wish to have a file-scoped package,
+This form is illegal in a Raku file.  If you wish to have a file-scoped package,
 either use the brace form or declare it with the C<module> keyword instead.
 
-Since there are no barewords in Perl 6, package names must be predeclared.
+Since there are no barewords in Raku, package names must be predeclared.
 Alternatively, the sigil-like C<::PackageName> syntax may be used to indicate
 that the type will be supplied some other way, however this syntax is not valid
 in declarative scenarios, especially parameter lists where it has entirely
 different semantics.  The C<::> prefix does not imply globalness as it does in
-Perl 5.  (Use C<GLOBAL::> for that.)
+Perl.  (Use C<GLOBAL::> for that.)
 
 A bare C<package> declarator (without an explicit scope declarator
 such as C<my>) declares an C<our> package within the current package
@@ -64,7 +64,7 @@ To declare an anonymous package you can use either of
 All files start out being parsed in the C<GLOBAL>
 package, but may switch to some other package scope depending on the first
 package-ish declaration.  If that first declaration is not a package variant, then
-the parsing switches to the "C<main>" package for Perl 5 code.  Perl 6 code
+the parsing switches to the "C<main>" package for Perl code.  Raku code
 stays C<GLOBAL> in that situation.  The mainline code is thus in the
 C<GLOBAL> namespace unless declared otherwise.
 
@@ -139,7 +139,7 @@ package up through the containing packages to C<GLOBAL>.  If it is not found,
 a compiler error results.
 
 As with an initial C<::>, the presence of a C<::> within the name
-does not imply globalness (unlike in Perl 5).  True globals are always
+does not imply globalness (unlike in Perl).  True globals are always
 in the C<GLOBAL::> namespace.
 
 The C<PROCESS::> namespace, shared by all interpreters within the process,
@@ -150,7 +150,7 @@ locate C<$PROCESS::PID> if not hidden by an inner callframe's C<$*PID>.)
 =head1 Autoloading
 
 A package (or any other similar namespace) can control autoloading.
-However, Perl 5's C<AUTOLOAD> is being superseded by MMD autoloaders
+However, Perl's C<AUTOLOAD> is being superseded by MMD autoloaders
 that distinguish declaration from definition, but are not restricted
 to declaring subs.  A run-time declarator multisub is declared as:
 
@@ -175,7 +175,7 @@ The package itself is just passed as the first argument, since it's
 the container object.  Subsequent arguments identify the desired type
 of the inner container and the "name" or "key" by which the object is
 to be looked up in the outer container.  Such a name does not include
-its container name, unlike Perl 5's magical C<$AUTOLOAD> variable.
+its container name, unlike Perl's magical C<$AUTOLOAD> variable.
 Nor does it include the type information of a Code object's "long
 name"; this information comes in via the type parameter, and may be
 matched against using ordinary subsignature matching:
@@ -183,8 +183,8 @@ matched against using ordinary subsignature matching:
     multi CANDO ( MyPackage, &:($), $name, *%args)     # 1 arg
     multi CANDO ( MyPackage, &:($,$), $name, *%args)   # 2 args
 
-The slurpy C<%args> hash is likely to be empty in standard Perl 6
-usage, but it's possible that some dialects of Perl will desire
+The slurpy C<%args> hash is likely to be empty in standard Raku
+usage, but it's possible that some dialects of Raku will desire
 a mechanism to pass in additional contextual information, so this
 parameter is reserved for such purposes.
 
@@ -216,7 +216,7 @@ inherited but may still do MMD within the class.   (Ordinary multisubs
 are "inherited" only to the extent allowed by nested lexical scopes.)
 
 When the package in question is not a class, there is a slight problem
-insofar as Perl 6 doesn't by default look into packages for functions
+insofar as Raku doesn't by default look into packages for functions
 anymore, only lexical scopes.  However, we'd still like the ability
 to dynamic add functions to a package, so there are two ways to get
 around the lexical limitation.

--- a/S11-modules.pod
+++ b/S11-modules.pod
@@ -18,32 +18,32 @@ been in Apocalypse 11.
 
 =head1 Units
 
-Perl 6 code is compiled per compilation unit, or I<compunit> for short.  These
+Raku code is compiled per compilation unit, or I<compunit> for short.  These
 are loaded with a C<use>, C<need> or C<require> statement (usually at compile
 time).  Or they are created as a string in a variable and compiled with an
 C<EVAL> statement (usually at runtime).  This synopsis is mostly about
 compunits loaded at compile time.
 
-In the common vernacular of a Perl 5 developer, a I<module> is the same as the
-file that contains the source code of a package.  For Perl 6 developers, this
+In the common vernacular of a Raku developer, a I<module> is the same as the
+file that contains the source code of a package.  For Raku developers, this
 is generally not much different.  However, such a I<module> is really a
 compunit that may contain 0 or more package-like statements, some of which
-may be I<module>.  Confusing?  Yes it is.  On top of that, Perl 6 allows
+may be I<module>.  Confusing?  Yes it is.  On top of that, Raku allows
 different versions of the same compunit to be installed in a single
 I<repository>.  And it allows compunits from other languages to be loaded.
 
-In Perl, the C<use> statement is really just telling Perl to find a compunit
+In Raku, the C<use> statement is really just telling Raku to find a compunit
 for the given name and load its contents.  Whether that name is the name of a
 C<package>, C<module>, C<class>, C<grammar> or C<role>, a combination of these
 or something else entirely in a C<slang>, is B<not> known at the moment the
 compunit is searched for (and hopefully found).  Only when the contents of the
-compunit are compiled, does Perl find out what's inside.
+compunit are compiled, does Raku find out what's inside.
 
-In Perl 5, the compunit's name to filename translation is generally mechanical.
+In Perl, the compunit's name to filename translation is generally mechanical.
 C<Foo::Bar> will always refer to C<Foo/Bar.pm> in a directory: it does not need
 any outside information to find out the name of the file to be loaded.
 
-Perl 6 however, only knows about I<repositories> that contain compunits.  Each
+Raku however, only knows about I<repositories> that contain compunits.  Each
 repository is represented as an object with the L<CompUnitRepo> interface in
 the C<@?INC> array.  Whenever a compunit needs to be loaded, each element in
 the C<@?INC> is queried for the compunit, and any candidates are returned.
@@ -54,7 +54,7 @@ obtained and loaded.
 There are 2 standard implementations of the C<CompUnitRepo> interface:
 L<CompUnitRepo::Local::File> and L<CompUnitRepo::Local::Installation>.  The
 first is used whenever you're specifying the C<-I> parameter when running
-Perl 6.  The second is always used when searched for locally installed
+Raku.  The second is always used when searched for locally installed
 compunits as files in directories.  Of course, one is free to devise any
 other way of storing and searching for compunits, as long as C<API> is the
 same.
@@ -64,10 +64,10 @@ more information about the C<CompUnitRepo> interface.
 
 =head1 Modules
 
-As in Perl 5, a C<module> is just a kind of package.  Unlike in Perl 5, modules
+As in Perl, a C<module> is just a kind of package.  Unlike in Perl, modules
 and classes are declared with separate keywords, but they're still just
 packages with extra behaviors.  In the case of modules, the extra behavior is
-the availability of the C<export> trait and any associated support for Perl 6
+the availability of the C<export> trait and any associated support for Raku
 standard export semantics.
 
 A module is declared with the C<module> keyword.  There are two basic
@@ -81,9 +81,9 @@ declaration syntaxes:
 A named module declaration can occur as part of an expression, just like
 named subroutine declarations.
 
-Since there are no barewords in Perl 6, module names must be predeclared,
+Since there are no barewords in Raku, module names must be predeclared,
 or use the sigil-like C<::ModuleName> syntax.  The C<::> prefix does not
-imply globalness as it does in Perl 5.  (Use C<GLOBAL::> for that.)
+imply globalness as it does in Perl.  (Use C<GLOBAL::> for that.)
 
 A bare (unscoped) C<module> declarator declares a nested C<our> module
 name within the current package.  However, at the start of a compunit,
@@ -95,12 +95,12 @@ You can use C<our module> to explicitly declare a module in the current
 package.  To declare a lexically scoped module, use C<my module>.
 Module names are always searched for from innermost scopes to outermost.
 As with an initial C<::>, the presence of a C<::> within the name
-does not imply globalness (unlike in Perl 5).
+does not imply globalness (unlike in Perl).
 
 The default package for the main program is C<GLOBAL>.
 (Putting C<module GLOBAL;> at the top of your program
-is redundant, except insofar as it tells Perl that the code is Perl
-6 code and not Perl 5 code.  But it's better to say C<use v6> for that.)
+is redundant, except insofar as it tells Perl that the code is Raku
+code and not Perl code.  But it's better to say C<use v6> for that.)
 
 Module traits are set using C<is>:
 
@@ -185,7 +185,7 @@ X<use>
 [Note: the :MY forms are being rethought currently.]
 
 Importing via C<use> binds into the current lexical scope by default
-(rather than the current package, as in Perl 5).
+(rather than the current package, as in Perl).
 
     use Sense <&common @horse>;
 
@@ -254,7 +254,7 @@ to import):
     need ACME::Rocket;
     my $r = ACME::Rocket.new;
 
-This declaration is equivalent to Perl 5's:
+This declaration is equivalent to Perl's:
 
     use ACME::Rocket ();
 
@@ -390,26 +390,26 @@ Other than that, the semantics are identical to the direct form.
 =head1 Versioning
 
 Whenever an authority (such as a CPAN author or a company) posts a
-compilation unit as part of a distribution of Perl 6 code, or enters it into
-any Perl 6 library, the module is required to declare its full
+compilation unit as part of a distribution of Raku code, or enters it into
+any Raku library, the module is required to declare its full
 name so that installations can know its unique, immutable identity,
 such that multiple versions by different authors can coexist, all of
-them available to any installed version of Perl.  (For the purposes of
-"standard Perl 6 library" we do not just mean publicly shared libraries
+them available to any installed version of Raku.  (For the purposes of
+"standard Raku library" we do not just mean publicly shared libraries
 such as CPAN, but also any internal or site-wide libraries that are
 shared outside the given module's dev group.)
 
 Such modules are also required to specify exactly which version (or
-versions) of Perl they are expecting to run under, so that future
-versions of Perl can emulate older versions of Perl (or give a cogent
+versions) of Raku they are expecting to run under, so that future
+versions of Raku can emulate older versions of Raku (or give a cogent
 explanation of why they cannot).  This will allow the language to
-evolve without breaking existing widely used modules.  (Perl 5 library
+evolve without breaking existing widely used modules.  (Perl library
 policy is notably lacking here; it would induce massive breakage even
-to change Perl 5 to make strictness the default.)  If an installed module
-breaks because it declares that it supports future versions of Perl
+to change Perl to make strictness the default.)  If an installed module
+breaks because it declares that it supports future versions of Raku
 when it doesn't, then it must be construed to be the module's fault,
-not Perl's.  If Perl evolves in a way that does not support emulation
-of an older version (at least, back to 6.0.0), then it's Perl's fault
+not Raku's.  If Raku evolves in a way that does not support emulation
+of an older version (at least, back to 6.0.0), then it's Raku's fault
 (unless the change is required for security, in which case it's the
 fault of the insensitive clod who broke security :).
 
@@ -474,21 +474,21 @@ If you say:
 
 which is short for:
 
-    use Perl:ver<6.*>;
+    use Raku:ver<6.*>;
 
-you're asking for any version of Perl 6.  You need to say something like
+you're asking for any version of Raku.  You need to say something like
 
-    use Perl:<6.0>;
-    use Perl:<6.0.0>;
-    use Perl:<6.2.7.1>;
+    use Raku:<6.0>;
+    use Raku:<6.0.0>;
+    use Raku:<6.2.7.1>;
 
 if you want to lock in a particular set of semantics at some greater
-degree of specificity.  And if some large company ever forks Perl, you can say
+degree of specificity.  And if some large company ever forks Raku, you can say
 something like:
 
-    use Perl:auth<cpan:TPF>
+    use Raku:auth<cpan:TPF>
 
-to guarantee that you get the unembraced Perl.  C<:-)>
+to guarantee that you get the unembraced Raku.  C<:-)>
 
 When it happens that the same module is available from more than one
 auth, and the desired auth is not specified by the C<use>,
@@ -559,7 +559,7 @@ And saying
 specifically rules out any prereleases.
 
 If two different compunits in your program require two different
-versions of the same compunit, Perl will simply load both versions at
+versions of the same compunit, Raku will simply load both versions at
 the same time.  For compunits that do not manage exclusive resources,
 the only penalty for this is memory, and the disk space in the library
 to hold both the old and new versions.  For compunits that do manage
@@ -598,27 +598,27 @@ care about the version, the newest will be used.
 
 =back
 
-=head1 Forcing Perl 6
+=head1 Forcing Raku
 
-To get Perl 6 parsing rather than the default Perl 5 parsing,
-we said you could force Perl 6 mode in your main program with:
+To get Raku parsing rather than the default Perl parsing,
+we said you could force Raku mode in your main program with:
 
     use v6;
 
-Actually, if you're running a parser that is aware of Perl 6, you
+Actually, if you're running a parser that is aware of Raku, you
 can just start your main program with any of:
 
     use v6;
     unit module;
     unit class;
 
-Those all specify the latest Perl 6 semantics, and are equivalent to
+Those all specify the latest Raku semantics, and are equivalent to
 
-    use Perl:auth(Any):ver(v6..*);
+    use Raku:auth(Any):ver(v6..*);
 
 To lock the semantics to 6.0.0, say one of:
 
-    use Perl:ver<6.0.0>;
+    use Raku:ver<6.0.0>;
     use :<6.0.0>;
     use v6.0.0;
 
@@ -629,34 +629,34 @@ in your main program. To start it in I<lax> mode, start it with
 
 (Invoking perl with C<-e> has the same effect.)
 
-In the other direction, to inline Perl 5 code inside a Perl 6 program, put
+In the other direction, to inline Perl code inside a Raku program, put
 C<use v5> at the beginning of a lexical block.  Such blocks can nest arbitrarily
-deeply to switch between Perl versions:
+deeply to switch between versions:
 
     use v6;
-    # ...some Perl 6 code...
+    # ...some Raku code...
     {
         use v5;
-        # ...some Perl 5 code...
+        # ...some Perl code...
         {
             use v6;
-            # ...more Perl 6 code...
+            # ...more Raku code...
         }
     }
 
-It's not necessary to force Perl 6 if the interpreter or command
+It's not necessary to force Raku if the interpreter or command
 specified already implies it, such as use of a "C<#!/usr/bin/perl6>"
-shebang line.  Nor is it necessary to force Perl 6 in any file that
+shebang line.  Nor is it necessary to force Raku in any file that
 begins with the C<unit>, C<class>, C<module>, C<grammar> or C<role> keywords.
 
 =head1 Tool use vs language changes
 
 In order that language processing tools know exactly what language
 they are parsing, it is necessary for the tool to know exactly which
-variant of Perl 6 is being parsed in any given scope.  All Perl 6
+variant of Raku is being parsed in any given scope.  All Raku
 compilation units that are complete files start out at the top of the
 file in the Standard Dialect (which itself has versions that correspond
-to the same version of the official Perl test suite).  C<EVAL> strings,
+to the same version of the official Raku test suite).  C<EVAL> strings,
 on the other hand, start out in the language variant in use at the
 point of the C<EVAL> call, so that you don't suddenly lose your macro
 definitions inside C<EVAL>.
@@ -667,7 +667,7 @@ macros and such, or such definitions may be imported from a package.
 As the compiler progresses through the compilation unit, other grammars
 may be substituted in an inner lexical scope for an outer grammar,
 and parsing continues under the new grammar (which may or may not be
-a derivative of the standard Perl grammar).
+a derivative of the standard Raku grammar).
 
 Language tweaks are considered part of the interface of any package
 you import.  Version numbers are assumed to represent a combination of
@@ -684,7 +684,7 @@ to hold branches without relinquishing overall naming authority.)
 
 So anyway, the basic rule is this: you may import language tweaks from
 your own private (user-library as specified in @?INC) code as you like;
-however, all imports of language tweaks from the installed Perl 6
+however, all imports of language tweaks from the installed Raku
 library must specify the exact interface version of the package.
 
 Such installed interface versions must be considered

--- a/S12-objects.pod
+++ b/S12-objects.pod
@@ -23,15 +23,15 @@ A class is a module declared with the C<class> keyword.  As with
 modules, the public storage, interface, and name of the class is
 represented by a package and its name, which is usually (but not
 necessarily) a global name.  A class is a module and thus can export
-stuff, but a class adds even more behavior to support Perl 6's
+stuff, but a class adds even more behavior to support Raku's
 standard class-based OO.
 
 Taken as a type object, a class name represents all of the possible values of
 its type, and the type object can thus be used as a proxy for any
 "real" object of that type in calculating what a generic object of
 that type can do.  The class object is an object, but it is not a
-Class, because there is no mandatory Class class in Perl 6, and because type
-objects in Perl 6 are considered undefined.  We wish
+Class, because there is no mandatory Class class in Raku, and because type
+objects in Raku are considered undefined.  We wish
 to support both class-based and prototype-based OO programming.
 So all metaprogramming is done through the current object's C<HOW>
 object, which can delegate metaprogramming to any metamodel it likes.
@@ -86,7 +86,7 @@ Classes are primarily for instance management, not code reuse.
 Consider using roles when you simply want to factor out
 common code.
 
-Perl 6 supports multiple inheritance, anonymous classes, and autoboxing.
+Raku supports multiple inheritance, anonymous classes, and autoboxing.
 
 All public method calls are "virtual" in the C++ sense.
 
@@ -94,7 +94,7 @@ You may derive from any built-in type, but the derivation of a low-level
 type like C<int> may only add behaviors, not change the representation.
 Use composition and/or delegation to change the representation.
 
-Since there are no barewords in Perl 6, bare class names must be
+Since there are no barewords in Raku, bare class names must be
 predeclared.  You can predeclare a stub class and fill it in later
 just as you would a subroutine.
 
@@ -115,7 +115,7 @@ class), use C<our class> or just C<class>.  To declare a lexically
 scoped class, use C<my class>.  Class names are always searched
 for from innermost scopes to outermost.  As with an initial C<::>,
 the presence of a C<::> within the name does not imply globalness
-(unlike in Perl 5).  So the outward search can look in children
+(unlike in Perl).  So the outward search can look in children
 of the searched namespaces.
 
 An inner class or role in a generic context must be lexically scoped
@@ -168,9 +168,9 @@ applied directly to the role rather than to the composed class.)
 Every object (including any class-based object) delegates to an instance
 of its metaclass.  You can get at the metaclass of any object via the
 C<HOW> method, which returns an instance of the metaclass.  A "class"
-object is just considered an "empty" instance in Perl 6, more properly
+object is just considered an "empty" instance in Raku, more properly
 called a "prototype" or "generic" object, or just "type object".
-Perl 6 doesn't really have any classes named C<Class>.  Types of all
+Raku doesn't really have any classes named C<Class>.  Types of all
 kinds are instead named via these undefined type objects, which are
 considered to have exactly the same type as an instantiated version of
 themselves.  But such type objects are inert, and do not manage the
@@ -201,7 +201,7 @@ so you should probably use those instead anyway.
 =head2 Private classes
 
 A private class can be declared using C<my>; most privacy issues are
-handled with lexical scoping in Perl 6.  The fact that importation
+handled with lexical scoping in Raku.  The fact that importation
 is lexical by default also means that any names your class imports
 are also private by default.
 
@@ -346,9 +346,9 @@ as a quote and then the result of that is used as the method name.
 
     $obj!"$methodname"()          # indirect call to private method name
 
-As an aid to catching Perl 5 brainos, this quoted form always requires
+As an aid to catching Perl brainos, this quoted form always requires
 a parenthesized argument list to distinguish it from code that looks
-like a Perl 5 concatenation.
+like a Perl concatenation.
 
 Within an interpolation, the double-quoted form may not contain
 whitespace.  This does what the user expects in the common case of
@@ -362,13 +362,13 @@ around this restriction with a closure interpolation:
     say "Foo = {$foo."a method"()}";  # OK
 
 [Note: to help catch the mistaken use of C<< infix:<.> >> as a string
-concatenation operator, Perl 6 will warn you about "useless use of
+concatenation operator, Raku will warn you about "useless use of
 quotes" at compile time if the string inside quotes is an identifier.
 (It does not warn about non-identifier strings, but such strings are
 likely to produce missing method errors at run time in any case.)
 Also, if there is whitespace around an intended C<.> concatenation,
 it cannot be parsed as a method call at all; instead it fails at
-compile time because standard Perl 6 has a pseudo C<< infix:<.> >> operator
+compile time because standard Raku has a pseudo C<< infix:<.> >> operator
 that always fails at compile time.]
 
 For situations where you already have a method located, you
@@ -628,7 +628,7 @@ to multi methods.
 =head1 Class methods
 
 Other OO languages give you the ability to declare "class" methods that
-either don't need or actively prohibit calls on instances.  Perl 6 gives
+either don't need or actively prohibit calls on instances.  Raku gives
 you a choice.  If you declare an ordinary method, it can function as a
 "class" method when you pass it a type object such as "C<Dog>" regardless
 of how defined the prototype object is, as long as the method body doesn't
@@ -807,8 +807,8 @@ the undefined type, all instances of the class, and all subclasses.
 All classes inherit a default C<new> constructor from C<Mu>.  It
 expects all arguments to be named parameters initializing attributes of
 the same name.  You may write your own C<new> to override the default,
-or write constructors with any other name you like.  As in Perl 5,
-a constructor is any routine that calls C<bless>.  Unlike in Perl 5,
+or write constructors with any other name you like.  As in Perl,
+a constructor is any routine that calls C<bless>.  Unlike in Perl,
 you call it as a method on the class object (though any object may be
 used as a class object), passing the arguments to be used in building
 the object.
@@ -938,7 +938,7 @@ The C<WALK> method takes these arguments:
     :canonical      # canonical dispatch order
     :ascendant      # most-derived first, like destruction order
     :descendant     # least-derived first, like construction order
-    :preorder       # like Perl 5 dispatch
+    :preorder       # like Perl dispatch
     :breadth        # like multi dispatch
 
     :super              # only immediate parent classes
@@ -1076,7 +1076,7 @@ a C<multi> or C<proto> declaration to share the same scope with an
 C<only> declaration of the same short name.
 
 Since they come from a different file, the default C<proto>
-declarations provided by Perl from the setting scope do I<not>
+declarations provided by Raku from the setting scope do I<not>
 automatically set the defaults in the user's scope unless explicitly
 imported, so a C<sub> declaration there that happens to be the same
 as a setting C<proto> is considered C<only> unless explicitly marked
@@ -1131,7 +1131,7 @@ or traits attached to the C<proto> may also be passed along to the
 routines within its scope, so a C<proto> definition can be used to factor
 out common traits.  This is particularly useful for establishing
 grammatical categories in a grammar by declaring a C<proto> C<token>
-or C<proto> C<rule>.  (Perl 6's grammar does this, for instance.)
+or C<proto> C<rule>.  (Raku's grammar does this, for instance.)
 
 =head2 C<multi> Variables
 
@@ -1183,7 +1183,7 @@ topological sort takes into account the presence of at least one
 constraint, but nothing about the number or nature of any additional
 constraints.  If we think of Int' as any constrained version of Int,
 then Int' is always tighter nominally than Int.  (Int' is a meta-notation,
-not Perl 6 syntax.)
+not Raku syntax.)
 
 The order in which candidates are considered is defined by a
 topological sort based on the "type narrowness" of each candidate's
@@ -1339,7 +1339,7 @@ prefixed with a C<my> or C<our> declarator.
 Multi submethods work just like multi methods except they are constrained
 to an exact type match on the invocant, just as ordinary submethods are.
 
-Perl 6.0.0 is not required to support multiple dispatch on named
+Raku is not required to support multiple dispatch on named
 parameters, only on positional parameters.  Note however that any
 dispatcher derived from C<proto> will map named arguments to known
 declared positional parameters and call the C<multi> candidates with
@@ -1373,8 +1373,8 @@ A subroutine call considers only visible subroutines (including
 submethods) of that name.  The object itself has no say in the
 dispatch; the subroutine dispatcher considers only the types the
 arguments involved, along with the name.  Hence foreign objects passed
-to subroutines are forced to follow Perl semantics (to the extent
-foreign types can be coerced into Perl types, otherwise they fail).
+to subroutines are forced to follow Raku semantics (to the extent
+foreign types can be coerced into Raku types, otherwise they fail).
 
 There is no fail-over either from subroutine to method dispatch or
 vice versa.  However, you may use C<is export> on a method
@@ -1512,7 +1512,7 @@ also be based on the return value of a method:
 
 =head1 Types and Subtypes
 
-The type system of Perl consists of roles, classes, and subtypes.
+The type system of Raku consists of roles, classes, and subtypes.
 You can declare a subtype like this:
 
     my subset Str_not2b of Str where /^[isnt|arent|amnot|aint]$/;
@@ -1544,7 +1544,7 @@ type specified, which is why we use the C<subset> keyword for it.
 While subtypes are primarily intended for restricting parameter types
 for multiple dispatch, they also let you impose preconditions on
 assignment.  If you declare any container with a subtype,
-Perl will check the constraint against any value you might try to
+Raku will check the constraint against any value you might try to
 bind or assign to the container.
 
     subset Str_not2b of Str where /^[isnt|arent|amnot|aint]$/;
@@ -1640,7 +1640,7 @@ That is, these mean something like:
 where C<DEFINITE> is a boolean macro that says whether the object
 in question has a valid concrete representation (see L</Introspection> below).
 
-In standard Perl 6, C<Int> is generally assumed to mean C<Int:_>, except
+In standard Raku, C<Int> is generally assumed to mean C<Int:_>, except
 for invocants, where the default is C<Int:D>.  (The default C<new> method
 has a prototype whose invocant is C<:U> instead, so all new methods all
 default to allowing type objects.)
@@ -1782,9 +1782,9 @@ easily known at compile time, and consider the presence of one or
 more dynamic constraints to be epsilon narrower than the same set of
 possible values without a dynamic constraint.
 
-As a first approximation for 6.0.0, subsets of enums are static,
+As a first approximation for Raku, subsets of enums are static,
 and other subsets are dynamic.  We may refine this in subsequent
-versions of Perl.
+versions of Raku.
 
 =head1 Enumerations
 
@@ -1940,7 +1940,7 @@ compile time.  Use a coercion to C<EnumMap> to get a run-time map.
 
 The enumeration composer inspects list values for pairs, where the value
 of the pair sets the next value explicitly.  Non-pairs C<++> the
-previous value.  (Str and buf types increment like Perl 5 strings.)
+previous value.  (Str and buf types increment like Perl strings.)
 Since the C<«...»> quoter automatically recognizes
 pair syntax along with interpolations, we can simply say:
 
@@ -2166,7 +2166,7 @@ C<.enums> method described above.
 
 =head1 Open vs Closed Classes
 
-By default, all classes in Perl are non-final, which means
+By default, all classes in Raku are non-final, which means
 you can potentially derive from them.  They are also open, which means
 you can add more methods to them, though you have to be explicit that
 that is what you're doing:
@@ -2185,7 +2185,7 @@ allowed on global classes unless you put a special declaration at the top:
 
     use MONKEY-TYPING;
 
-For optimization purposes, Perl 6 gives the top-level application the
+For optimization purposes, Raku gives the top-level application the
 right to close and finalize classes by the use of C<oo>, a pragma for
 selecting global semantics of the underlying object-oriented engine:
 
@@ -2231,7 +2231,7 @@ unmarked classes.
 
 =head1 Representations
 
-By default Perl 6 assumes that all objects have a representation
+By default Raku assumes that all objects have a representation
 of C<P6opaque>.  This may be overridden with a trait:
 
     class Mammal is repr(P6Hash) {...}
@@ -2255,7 +2255,7 @@ on run-time information, as long as correct semantics are maintained.
 All non-native representations are required to support undefined type
 objects that may contain unthrown exceptions (C<Failure> objects);
 while this can be implemented using an alternate representation,
-Perl 6 doesn't think of it that way.  All normal objects in Perl 6
+Raku doesn't think of it that way.  All normal objects in Raku
 may be used as a specific object (proper noun) if they are defined,
 or as a generic object (common noun) whether or not they are defined.
 You get this representation polymorphism for free independently of
@@ -2327,7 +2327,7 @@ There is one more macro:
 
 The C<DEFINITE> macro serves as the default for the C<Mu.defined> method.
 
-For now Perl 6 reserves the right to change how all these macros
+For now Raku reserves the right to change how all these macros
 and the corresponding C<^> forms are defined in terms of each other.
 In particular, the C<.^> forms will automatically supply the invocant
 as the first argument to methods of the metaclass, while the other
@@ -2335,14 +2335,14 @@ forms require you to pass this explicitly.
 
 Note that C<WHAT.gist> surrounds the name with parens to indicate undefinedness.
 Use C<.perl> to get the bare name from a type object.  Use one of
-C<.Str>, C<.Stringy>, C<< prefix:<~> >>, or C<< infix:<~> >> to get the Perl5ish
+C<.Str>, C<.Stringy>, C<< prefix:<~> >>, or C<< infix:<~> >> to get the Perlish
 semantics of returning the empty string (with a warning) on any type
-object.  (There is no "undef", in Perl 6; type objects provide typed
+object.  (There is no "undef", in Raku; type objects provide typed
 undefs instead.)
 
 In general, use of these uppercased accessors in ordinary code should
 be a red flag that Something Very Strange is going on.  (Hence the allcaps.)
-Most code should use Perl 6's operators that make use of this information
+Most code should use Raku's operators that make use of this information
 implicitly.  For instance, instead of
 
     $obj.WHAT === Dog
@@ -2392,7 +2392,7 @@ Class traits may include:
     disambig      how to deal with ambiguous method names from roles
     repr          P6opaque, P6hash, P5hash, P5array, PyDict, Cstruct, etc.
 
-These are for the standard Perl 6 Meta-Object Protocol, but other MOPs
+These are for the standard Raku Meta-Object Protocol, but other MOPs
 may define other traits.  The identifier should probably be accessed
 through the C<.WHO> object in any case, which may have its own object
 methods depending on how type namespaces evolve over time.  Which of
@@ -2506,8 +2506,8 @@ which is true if C<$obj> either "does" or "isa" C<Dog> (or "isa"
 something that "does" C<Dog>).  If C<Dog> is a subset, any additional
 C<where> constraints must also evaluate true.
 
-Unlike in Perl 5 where C<.can> returns a single C<Code> object,
-Perl 6's version of C<.^can> returns a "WALK" iterator for a
+Unlike in Perl where C<.can> returns a single C<Code> object,
+Raku's version of C<.^can> returns a "WALK" iterator for a
 set of routines that match the name, including all autoloaded and
 wildcarded possibilities.  In particular, C<.^can> interrogates
 any class package's C<CANDO> method for names that are to be considered
@@ -2519,7 +2519,7 @@ and hasn't been supplied by the class or one of its roles.
 The motivation for stopping at C<Cool> and C<Any> by default is that
 the first derivation from one of those is really what the user thinks
 of as the root class of the type hierarchy most of the time.  Methods
-outside of that are really part of Perl 6's lexicon, recognizable
+outside of that are really part of Raku's lexicon, recognizable
 across all types.  Hence if you say, for example, C<$object.sort>
 or C<$object.arctan>, you're invoking well-known cultural concepts
 that tend to transcend the user's type hierarchy.  When the user
@@ -2538,7 +2538,7 @@ reflect current implementation reality fairly well.]
 
 When the parser encounters a package declarator, it uses the name of
 the declarator (such as C<class> or C<grammar>) to look up the type of
-meta-object to use. The default meta-objects support the standard Perl 6
+meta-object to use. The default meta-objects support the standard Raku
 OO semantics. However, it is possible for a module to export different
 meta-objects with different semantics. This is done by declaring an
 C<EXPORTHOW> package, which should be located in C<UNIT> of the module
@@ -2640,7 +2640,7 @@ many long names due to signatured roles.
 
 Sometimes, it may be interesting to customize meta-object behaviour on a
 per-type basis. While this could be done by writing a custom meta-class and
-arranging for it to be used, Perl 6 permits overriding specific meta-methods
+arranging for it to be used, Raku permits overriding specific meta-methods
 on a per-type basis. For example, if the C<trusts> adverb was not flexible
 enough and the class instead wanted to implement a more custom policy on
 what other types it trusts, it could do something like:

--- a/S13-overloading.pod
+++ b/S13-overloading.pod
@@ -19,7 +19,7 @@ been in Apocalypse 13.
 
 =head1 Multiple dispatch
 
-The overloading mechanism of Perl 5 has been superseded by Perl 6's
+The overloading mechanism of Perl has been superseded by Raku's
 multiple dispatch mechanism.  Nearly all internal functions
 are defined as C<multi> subs or C<multi> methods on generic types.
 Built-in operators are merely oddly named functions with an alternate
@@ -28,7 +28,7 @@ own C<multi> subs and methods that operate on arguments with more
 specific types.
 
 For unary operators, this makes little effective difference, but for
-binary operators, multiple dispatch fixes the Perl 5 problem of paying
+binary operators, multiple dispatch fixes the Perl problem of paying
 attention only to the type of the left argument.  Since both argument
 types are used in deciding which routine to call, there is no longer
 any trickery involving swapping the arguments to use the right argument's
@@ -63,9 +63,9 @@ strings so you can handle various ligatures, you can say:
     multi sub infix:<~>(Str $s1, ArabicStr $s2) {...}
     multi sub infix:<~>(ArabicStr $s1, Str $s2) {...}
 
-The C<use overload> syntax had one benefit over Perl 6's syntax in that
+The C<use overload> syntax had one benefit over Raku's syntax in that
 it was easy to alias several different operators to the same service
-routine.  This can easily be handled with Perl 6's aliasing:
+routine.  This can easily be handled with Raku's aliasing:
 
     multi sub unimpl (MyFoo $x, MyFoo $y) { upchuck(); }
     &infix:<+> ::= &unimpl;
@@ -88,7 +88,7 @@ if any declared type of the first parameter is consistent with C<$?CLASS>.
 
 Dispatch is based on a routine's signature declaration without regard
 to whether the routine is defined yet.  If an attempt is made to
-dispatch to a declared but undefined routine, Perl will redispatch
+dispatch to a declared but undefined routine, Raku will redispatch
 to an C<AUTODEF> submethod [conjectural] as appropriate to define the routine.  This provides
 a run-time mechanism for fallbacks.  By default, these declarations
 are taken at face value and do not specify any underlying semantics.
@@ -114,7 +114,7 @@ The mappings of magical names to sub definitions is controlled by the
 C<%?DEEPMAGIC> compiler hash.  Pragmas can influence the contents of
 this hash over a lexical scope, so you could have different policies
 on magical autogeneration.  The default mappings correspond to the
-standard fallback mappings of Perl 5 overloading.
+standard fallback mappings of Perl overloading.
 
 These deep mappings are mainly intended for infix operators that would have
 difficulty naming all their variants.  Prefix operators tend to be simpler;

--- a/S14-roles-and-parametric-types.pod
+++ b/S14-roles-and-parametric-types.pod
@@ -19,7 +19,7 @@ originally discussed in A12.
 =head1 Roles
 
 Classes are primarily in charge of object management, and only
-secondarily in charge of software reuse.  In Perl 6, roles take over
+secondarily in charge of software reuse.  In Raku, roles take over
 the job of managing software reuse.  Depending on how you care to look
 at it, a role is like a partial class, or an interface with default
 implementation, or a set of generic methods and their associated data,
@@ -576,7 +576,7 @@ C<CurriedRoleHOW> that will pass along the extra type parameters at the
 point of composition, to aid selection of the correct parametric variant.
 Therefore, it does not address a particular C<ParametricRoleHOW>.
 
-Normal users of Perl 6 will have to care little for these details. However,
+Normal users of Raku will have to care little for these details. However,
 given that any C<our> scoped symbol declared inside of a role body will end
 up in a package that is simply unaddressable without digging into the
 meta-objects, C<our> declarations in a role are forbidden. This does not
@@ -587,7 +587,7 @@ access them.
 
 =head2 Interaction of typed and untyped data structures
 
-Certainly so far as Perl 6.0.0 goes, only types that have been declared
+Certainly so far as Raku goes, only types that have been declared
 on a container count in the type check. That is, if we have a sub:
 
     sub f(Int @arr) { ... }

--- a/S15-unicode.pod
+++ b/S15-unicode.pod
@@ -10,7 +10,7 @@
     Last Modified    10 October 2014
     Version          8
 
-This document describes how Unicode and Perl 6 work together. Needless to say,
+This document describes how Unicode and Raku work together. Needless to say,
 it would be good for your chosen reader to support various Unicode characters.
 
 =head1 String Base Units
@@ -47,10 +47,10 @@ bytes, the perceived length of the string differs:
     | graphemes  | 1     | 1      | 1      |
     |------------+-------+--------+--------|
 
-Perl 6 offers various mechanisms to count by each of these "base units" of a
+Raku offers various mechanisms to count by each of these "base units" of a
 string.
 
-Perl 6 by default operates on graphemes, so counting by graphemes involves:
+Raku by default operates on graphemes, so counting by graphemes involves:
 
     "string".chars
 
@@ -77,15 +77,15 @@ is always the same.
 
 =head2 NFG
 
-Perl 6, by default, stores all strings given to it in NFG form, Normalization
-Form Grapheme. It's a Perl 6–invented character representation, designed to deal
+Raku, by default, stores all strings given to it in NFG form, Normalization
+Form Grapheme. It's a Raku–invented character representation, designed to deal
 with un-precomposed graphemes properly.
 
-Formally Perl 6 graphemes are defined exactly according to Unicode Grapheme Cluster Boundaries
+Formally Raku graphemes are defined exactly according to Unicode Grapheme Cluster Boundaries
 at level "extended" (in contrast to "tailored" or "legacy"),
 see Unicode Standard Annex #29 UNICODE TEXT SEGMENTATION
 L<3 Grapheme Cluster Boundaries|http://www.unicode.org/reports/tr29/tr29-25.html#Grapheme_Cluster_Boundaries>>.
-This is the same as the Perl 5 character class
+This is the same as the Perl character class
 
   \X   Match Unicode "eXtended grapheme cluster"
 
@@ -99,7 +99,7 @@ changes to Unicode.  The mapping between these internal designations and
 graphemes in this form is not guaranteed constant, even between strings in
 the same process.
 
-The Perl 6 C<Str> type, and more generally the C<Stringy> role, deals
+The Raku C<Str> type, and more generally the C<Stringy> role, deals
 exclusively in NFG form.
 
 =head2 NFC and NFD
@@ -113,7 +113,7 @@ possible, after first running it through the NFD process.
 These two Normalization Forms are similar to NFG, except that graphemes without
 precomposed versions exist as multiple codepoints.
 
-NFC is the form Perl 6 uses whenever NFG is not viable, such as printing the
+NFC is the form Raku uses whenever NFG is not viable, such as printing the
 string to stdout or passing it to a C<{ use v5; }> section.
 
 =head2 NFKC and NFKD
@@ -133,7 +133,7 @@ though each differ in their exact formulation of the contents of a string:
     say "ẛ̣".NFKD.codes;          # OUTPUT: 3 (NFKD, s + ̣+ ̇)
 
 Those who wish to operate with strings on the codepoint level may wish to use
-NFC, as it is the least different from NFG, as well as Perl 6's default form for
+NFC, as it is the least different from NFG, as well as Raku's default form for
 NFG-less contexts.
 
 All of C<Uni>, C<NFC>, C<NFD>, C<NFKC>, and C<NFKD>, and more generally the
@@ -184,7 +184,7 @@ UTF-16 and UTF-32 default to big endian if you don't specify endianness.
 
 =head1 The C<NF*> Types
 
-Perl 6 has four types corresponding to a specific Unicode Standard Normalization
+Raku has four types corresponding to a specific Unicode Standard Normalization
 Form: C<NFC>, C<NFD>, C<NFKC>, and C<NFKD>.
 
 Each one of these types perform normalization on strings stored in it.
@@ -255,7 +255,7 @@ transposition of the string without changes in normalization.
 
 =head1 Unicode Information
 
-There's plenty of information each Unicode codepoint possesses, and Perl 6
+There's plenty of information each Unicode codepoint possesses, and Raku
 provides various ways of accessing that information.
 
 Unless plural forms of these functions are provided, each function operates only
@@ -597,7 +597,7 @@ The typical C<:nf> adverbs are in use here.
 
 =head2 Identifiers
 
-Identifiers in Perl 6 can start with any alphabetic character (those characters
+Identifiers in Raku can start with any alphabetic character (those characters
 in the C<L> category, as well as underscore), followed by any number of
 alphanumeric characters (those characters in the C<L> or C<N> category, as well
 as underscore). Dashes (C<->) and apostrophes (C<'>) may also appear, provided
@@ -610,7 +610,7 @@ that they are followed by an alphabetic character.
 Combining marks (characters in the C<M> category) may not be the first character
 in an identifier, but they may appear at any time afterwards.
 
-Perl 6 internally stores all identifiers in NFG form, so these two lines create
+Raku internally stores all identifiers in NFG form, so these two lines create
 the same variable (and throw a redeclaration warning if used like this in code):
 
     my $ä; # precomposed
@@ -618,7 +618,7 @@ the same variable (and throw a redeclaration warning if used like this in code):
 
 =head2 Numbers
 
-Similar to its support for any kind of Unicode in identifiers, Perl 6 allows any
+Similar to its support for any kind of Unicode in identifiers, Raku allows any
 kind of character within the category C<Nd> (Decimal Number) for decimal
 numbers:
 
@@ -702,7 +702,7 @@ combining characters.]
 
 Regexes likely need more work, though I don't see anything immediate.
 
-Some easy way to change how Perl 6 handles language specific weirdness, possibly
+Some easy way to change how Raku handles language specific weirdness, possibly
 through another type (C<Rope>? C<Twine>? C<Yarn>?). A very small selection of
 those weirdnesses:
 

--- a/S16-io.pod
+++ b/S16-io.pod
@@ -12,7 +12,7 @@ Synopsis 16: I/O
     Last Modified: 5 Nov 2014
     Version: 28
 
-Many of these functions will work as in Perl 5, except we're trying to rationalize everything into roles.  For
+Many of these functions will work as in Perl, except we're trying to rationalize everything into roles.  For
 now you can assume most of the important functions will automatically
 be in the * namespace.  However, with IO operations in particular,
 many of them are really methods on an IO handle, and if there is a
@@ -23,13 +23,13 @@ the method.
 
 =head2 Overridable IO handles
 
-In Perl 6, there are the I<standard> IO handles, and any number of overriding
+In Raku, there are the I<standard> IO handles, and any number of overriding
 inner filehandles for the same symbol.
 
 The I<standard> handles are our old familiar friends (with new names).
 Standard input changed from STDIN to C<$*IN>, standard output changed
 from STDOUT to C<$*OUT>, and standard error changed from STDERR to
-C<$*ERR>.  In Perl 6 these symbols represent more of a concept than
+C<$*ERR>.  In Raku these symbols represent more of a concept than
 a given filehandle, since the meaning is contextually determined.
 The process's version of these handles live in the C<PROCESS::>
 namespace, which is more global than the per-interpreter C<GLOBAL::>
@@ -53,7 +53,7 @@ takes the closest definition it can find in its callers.  If none
 of the callers have overridden the definition, it looks in the
 interpreter's C<GLOBAL> namespace.  If the interpreter hasn't overridden
 the meaning, it takes the meaning from C<PROCESS>.  In essence, any
-dynamic scope in Perl 6 is allowed to do IO redirection much like
+dynamic scope in Raku is allowed to do IO redirection much like
 a Unix shell does with its subprocesses, albeit with a different
 syntax:
 
@@ -459,7 +459,7 @@ performance.
 
 =head1 AUTHORS
 
-    Largely, the authors of the related Perl 5 docs.
+    Largely, the authors of the related Perl docs.
     Larry Wall <larry@wall.org>
     Mark Stosberg <mark@summersault.com>
     Tim Nelson <wayland@wayland.id.au>

--- a/S17-concurrency.pod
+++ b/S17-concurrency.pod
@@ -17,7 +17,7 @@ This synopsis is based around the concurrency primitives and tools currently bei
 
 =head2 Focus on composability
 
-Perl 6 generally prefers constructs that compose well, enabling large problems to be solved by putting together solutions for lots of smaller problems. This also helps make it easier to extend and refactor code.
+Raku generally prefers constructs that compose well, enabling large problems to be solved by putting together solutions for lots of smaller problems. This also helps make it easier to extend and refactor code.
 
 Many common language features related to parallel and asynchronous programming lack composability. For example:
 
@@ -37,7 +37,7 @@ Directly spawning threads on a per-component basis tends to compose badly, as wh
 
 =back
 
-In Perl 6, concurrency features aimed at typical language users should have good composability properties, both with themselves and also with other language features.
+In Raku, concurrency features aimed at typical language users should have good composability properties, both with themselves and also with other language features.
 
 =head2 Boundaries between synchronous and asynchronous should be explicit
 
@@ -47,7 +47,7 @@ The vast majority of programmers are much more comfortable with synchrony, as in
 
 It's also worthwhile trying to make it easy to keep asynchronous things flowing asynchronously. While synchronous code is pull-y (for example, eating its way through iterable things, blocking for results), asynchronous code is push-y (results get pushed to things that know what to do next).
 
-Places where we go from synchronous to asynchronous, or from asynchronous to synchronous, are higher risk areas for bugs and potential bottlenecks. Thus, Perl 6 should try to provide features that help minimize the need to make such transitions.
+Places where we go from synchronous to asynchronous, or from asynchronous to synchronous, are higher risk areas for bugs and potential bottlenecks. Thus, Raku should try to provide features that help minimize the need to make such transitions.
 
 =head2 Implicit parallelism is OK
 
@@ -55,7 +55,7 @@ Parallelism is primarily about taking something we could do serially and using m
 
 While under the hood there is asynchrony and the inherent coordination it requires, on the outside a problem solved using parallel programming is still, when taken as a whole, a single, synchronous operation.
 
-Elsewhere in the specification, Perl 6 provides several features that allow the programmer to indicate that parallelizing an operation will produce the same result as evaluating it serially:
+Elsewhere in the specification, Raku provides several features that allow the programmer to indicate that parallelizing an operation will produce the same result as evaluating it serially:
 
 =over
 
@@ -79,13 +79,13 @@ C<hyper> and C<race> list operators (L<S02/The hyper operator>) express that ite
 
 =head2 Make the hard things possible
 
-The easy things should be easy, and able to be built out of primitives that compose nicely. However, such things have to be built out of what VMs and operating systems provide: threads, atomic instructions (such as CAS), and concurrency control constructs such as mutexes and semaphores. Perl 6 is meant to last for decades, and the coming decades will doubtless bring new ways do do parallel and asynchronous programming that we do not have today. They will still, however, almost certainly need to be built out of what is available.
+The easy things should be easy, and able to be built out of primitives that compose nicely. However, such things have to be built out of what VMs and operating systems provide: threads, atomic instructions (such as CAS), and concurrency control constructs such as mutexes and semaphores. Raku is meant to last for decades, and the coming decades will doubtless bring new ways do do parallel and asynchronous programming that we do not have today. They will still, however, almost certainly need to be built out of what is available.
 
-Thus, the primitive things should be provided for those who need to work on such hard things. Perl 6 should not hide the existence of OS-level threads, or fail to provide access to lower level concurrency control constructs. However, they should be clearly documented as I<not> the way to solve the majority of problems.
+Thus, the primitive things should be provided for those who need to work on such hard things. Raku should not hide the existence of OS-level threads, or fail to provide access to lower level concurrency control constructs. However, they should be clearly documented as I<not> the way to solve the majority of problems.
 
 =head1 Schedulers
 
-Schedulers lie at the heart of all concurrency in Perl 6. While most users are unlikely to immediately encounter schedulers when starting to use Perl 6's concurrency features, many of them are implemented in terms of it. Thus, they will be described first here to avoid lots of forward references.
+Schedulers lie at the heart of all concurrency in Raku. While most users are unlikely to immediately encounter schedulers when starting to use Raku's concurrency features, many of them are implemented in terms of it. Thus, they will be described first here to avoid lots of forward references.
 
 A scheduler is something that does the C<Scheduler> role. Its responsibility is taking code objects representing tasks that need to be performed and making sure they get run, as well as handling any time-related operations (such as, "run this code every second").
 
@@ -741,7 +741,7 @@ It can also take C<done> and C<quit> named parameters; these go to the tap, whil
 
 =head1 Inter-Process Communication exposed as Promises and Supplies
 
-Starting external processes is rather easy: C<shell()>, C<run()> and C<qx//>. Having external processes run asynchronously, is slightly more involved. But not much.  The workhorse of asynchronous IPC in Perl 6 is C<Proc::Async>:
+Starting external processes is rather easy: C<shell()>, C<run()> and C<qx//>. Having external processes run asynchronously, is slightly more involved. But not much.  The workhorse of asynchronous IPC in Raku is C<Proc::Async>:
 
     my $proc = Proc::Async.new( $path, @args );
 
@@ -857,9 +857,9 @@ Finally, the C<yield> method can be called on C<Thread> (not on any particular t
 
 =head2 Atomic Compare and Swap
 
-The Atomic Compare and Swap (CAS) primitive is directly supported by most modern hardware. It has been shown that it can be used to build a whole range of concurrency control mechanisms (such as mutexes and semaphores). It can also be used to implement lock-free data structures. It is decidedly a primitive, and not truly composable due to risk of livelock. However, since so much can be built out of it, Perl 6 provides it directly.
+The Atomic Compare and Swap (CAS) primitive is directly supported by most modern hardware. It has been shown that it can be used to build a whole range of concurrency control mechanisms (such as mutexes and semaphores). It can also be used to implement lock-free data structures. It is decidedly a primitive, and not truly composable due to risk of livelock. However, since so much can be built out of it, Raku provides it directly.
 
-A Perl 6 implementation of CAS would look something like this:
+A Raku implementation of CAS would look something like this:
 
     sub cas($ref is rw, $expected, $new) {
         my $seen = $ref;
@@ -917,7 +917,7 @@ It's the programmer's duty to ensure that the original data structure is never m
 
 =head1 Low-level primitives
 
-Perl 6 offers high-level concurrency methods, but in extreme cases, like if you need to implement a fundamentally different mechanism, these primitives are available.
+Raku offers high-level concurrency methods, but in extreme cases, like if you need to implement a fundamentally different mechanism, these primitives are available.
 
 =head2 Locks
 

--- a/S19-commandline.pod
+++ b/S19-commandline.pod
@@ -13,9 +13,9 @@ DRAFT: Synopsis 19: Command Line Interface
     Version: 28
 
 This is a draft document. This document describes the command line interface.
-It has changed extensively from previous versions of Perl in order to increase
+It has changed extensively from previous versions of Raku in order to increase
 clarity, consistency, and extensibility. Many of the syntax revisions are
-extensions, so you'll find that much of the Perl 5 syntax embedded in your
+extensions, so you'll find that much of the Perl syntax embedded in your
 muscle memory will still work.
 
 Notable features described in the sections below include:
@@ -44,7 +44,7 @@ New C<++> metasyntax allows options to be passed through to subsystems
 
 =back
 
-This interface to Perl 6 is special in that it occurs at the intersection of
+This interface to Raku is special in that it occurs at the intersection of
 the program and the operating system's command line shell, and thus is not
 accessed via a consistent syntax everywhere. A few assumptions are made here,
 which will hopefully stand the test of time: All command-line arguments are
@@ -69,26 +69,26 @@ variable (normally accessed as C<$*PROGRAM>) as an C<IO::Path>.
 Command line I<arguments> are broken down into I<options> and I<values>.
 Each option may take zero or more values. After all options have been
 processed, the remaining values (if any) generally consist of the name of a
-script for Perl to execute, followed by arguments for that script. If no
-values remain, Perl 6 implicitly opens STDIN to read the script. If you wish
+script for Raku to execute, followed by arguments for that script. If no
+values remain, Raku implicitly opens STDIN to read the script. If you wish
 to pass arguments to a script read from STDIN, you must specify STDIN by name
 (C<-> on most operating systems).
 
 
 =head1 Backward (In)compatibility
 
-You may find yourself typing your favorite Perl 5 options, even after
+You may find yourself typing your favorite Perl options, even after
 Christmas has arrived.  As you'll see below, common options are provided
 which behave similarly.  Less common options, however, may not be available
-or may have changed syntax.  If you provide Perl with unrecognized command-line
-syntax, Perl gives you a friendly error message.  If the unrecognized
-syntax is a valid Perl 5 option, Perl provides helpful suggestions to allow
+or may have changed syntax.  If you provide Raku with unrecognized command-line
+syntax, Raku gives you a friendly error message.  If the unrecognized
+syntax is a valid Perl option, Raku provides helpful suggestions to allow
 you to perform the same action using the current syntax.
 
 
 =head2 Unchanged Syntactic Features
 
-Several features have not changed from Perl 5, including:
+Several features have not changed from Perl, including:
 
 =over 4
 
@@ -126,8 +126,8 @@ different semantics, so see L</"Option Reference"> below for the details.
 
 =head2 Removed Syntactic Features
 
-Some Perl 5 command-line features are no longer available, either because
-there's a new and different way to do it in Perl 6, or because they're
+Some Perl command-line features are no longer available, either because
+there's a new and different way to do it in Raku, or because they're
 no longer relevant.  Here's a breakdown of what's been removed:
 
 =over 4
@@ -140,7 +140,7 @@ section at the end of this document.
 
 =item -C *number/list*
 
-Control Unicode features.  Perl 6 has Unicode semantics and assumes a
+Control Unicode features.  Raku has Unicode semantics and assumes a
 UTF-8 command-line interface (until proven otherwise, at which point this
 functionality may be readdressed).
 
@@ -151,7 +151,7 @@ Debugging commands.  Replaced with the C<++BUG> metasyntactic option.
 =item -E *line*
 
 Execute a line of code, with all features enabled.  This is specific to
-Perl 5.10, and not relevant to Perl 6, where C<-e> performs this function.
+Perl 5.10, and not relevant to Raku, where C<-e> performs this function.
 
 =item -i *extension*
 
@@ -168,11 +168,11 @@ use/no module.  Replaced by C<--use>.
 
 =item -P
 
-Run option through C preprocessor. This caused problems for Perl 5, and is completely obsolete now.
+Run option through C preprocessor. This caused problems for Perl, and is completely obsolete now.
 
 =item -s
 
-Enable rudimentary switch parsing.  By default, Perl 6 parses the
+Enable rudimentary switch parsing.  By default, Raku parses the
 arguments passed to a script using the signature supplied by the user
 in the MAIN routine (see L<S06/"Declaring a MAIN subroutine">).
 
@@ -246,7 +246,7 @@ negated options are rare anyway, as most boolean options default to False.
 
 =item *
 
-Option names follow Perl 6 identifier naming convention, except C<'> is not
+Option names follow Raku identifier naming convention, except C<'> is not
 allowed, and single-character options may be any character or number.
 
 =item *
@@ -302,10 +302,10 @@ like a closing HTML tag.
 These options are made available in dynamic variables matching their name,
 and are invisible to C<MAIN()> except as C<< %*OPTSZ<><name> >>.  For example:
 
-  ++PARSER --setting=Perl6-autoloop-no-print ++/PARSER
+  ++PARSER --setting=Raku-autoloop-no-print ++/PARSER
 
 is available inside your script as C<< %*OPTSZ<><PARSER> >>, and contains
-C<--setting=Perl6-autoloop-no-print>.  Since eager matching is used, if you
+C<--setting=Raku-autoloop-no-print>.  Since eager matching is used, if you
 need to pass something like:
 
   ++foo -bar ++foo baz ++/foo ++/foo
@@ -351,11 +351,11 @@ of the option, as in C<--option=val1 --option='val 2'>.
 
 =head2 Remaining arguments
 
-Any remaining arguments to the Perl 6 program are placed in the C<@*ARGS> array.
+Any remaining arguments to the Raku program are placed in the C<@*ARGS> array.
 
 =head1 Option Reference
 
-Perl 6 options, descriptions, and services.
+Raku options, descriptions, and services.
 
 =head2 Synopsis
 
@@ -404,7 +404,7 @@ Check syntax, then exit.  Desugars to C<-e 'CHECK { compiles_ok(); exit; }'>.
 
 =item --doc
 
-Lookup Perl documentation in Pod format.  Desugars to
+Lookup Raku documentation in Pod format.  Desugars to
 C<-e 'CHECK { compiles_ok(); dump_perldoc(); }'>. C<@*ARGS> contains the
 arguments passed to C<perl6>, and is available at C<CHECK> time, so
 C<dump_perldoc()> can respond to command-line options.
@@ -454,18 +454,18 @@ C<++PARSER --setting=*dsl* ++/PARSER>.
 =item --autoloop-no-print, -n
 
 Act like awk.  Desugars to
-C<++PARSER --setting=Perl6-autoloop-no-print ++/PARSER>.
+C<++PARSER --setting=Raku-autoloop-no-print ++/PARSER>.
 
 =item --output-format, -O *format*
 
 Emit compiler output to STDOUT in the specified format, rather than invoking
 the compiled code immediately. This option is implementation-specific, so
-consult the documentation for your Perl 6 implementation for further details.
+consult the documentation for your Raku implementation for further details.
 
 =item --autoloop-print, -p
 
 Act like sed.  Desugars to
-C<++PARSER --setting=Perl6-autoloop-print ++/PARSER>.
+C<++PARSER --setting=Raku-autoloop-print ++/PARSER>.
 
 =item --search-path, -S
 
@@ -504,7 +504,7 @@ This is useful for running a program embedded in a larger message.
 (In this case you would indicate the end of the program using the C<=END>
 block, as defined in L<Synopsis 26|S26-documentation/"The =END block">.)
 
-Desugars to C<--PARSER --Perl6-extract-from-text --/PARSER>.
+Desugars to C<--PARSER --Raku-extract-from-text --/PARSER>.
 
 =back
 
@@ -512,13 +512,13 @@ Desugars to C<--PARSER --Perl6-extract-from-text --/PARSER>.
 =head1 Metasyntactic Options
 
 Metasyntactic options are a subset of delimited options used to pass arguments
-to an underlying component of Perl. Perl itself does not parse these options,
+to an underlying component of Raku. Raku itself does not parse these options,
 but makes them available to run-time components via the C<%*META-ARGS> dynamic
 variable.
 
-Standard in Perl 6 are three underlying components, C<CMD>, C<PARSER>,
+Standard in Raku are three underlying components, C<CMD>, C<PARSER>,
 and C<BUG>.  Implementations may expose other components via this
-interface, so consult the documentation for your Perl 6 implementation.
+interface, so consult the documentation for your Raku implementation.
 
   On command line...                   Subsystem gets...
    ++X a -b  ++/X                      a -b
@@ -545,7 +545,7 @@ is used.
 
 =item PERL6LIB
 
-A list of directories in which to look for ad hoc Perl library files.
+A list of directories in which to look for ad hoc Raku library files.
 
 Note: this is speculative, as library loading is not yet specified,
 except insofar as S11 mandates various behaviors incompatible with
@@ -571,7 +571,7 @@ list of arguments provided on the command-line.
 
 =item L<http://design.perl6.org/S06.html#Declaring_a_MAIN_subroutine>
 
-=item L<http://search.cpan.org/dist/Perl6-Pugs/docs/Pugs/Doc/Run.pod>
+=item L<http://search.cpan.org/dist/Raku-Pugs/docs/Pugs/Doc/Run.pod>
 
 =item L<http://haskell.org/ghc/docs/latest/html/users_guide/using-ghc.html>
 

--- a/S21-calling-foreign-code.pod
+++ b/S21-calling-foreign-code.pod
@@ -25,7 +25,7 @@ The document is a draft.
 
 =head1 DESCRIPTION
 
-Perl 6 has a standard foreign function interface, NativeCall. The only
+Raku has a standard foreign function interface, NativeCall. The only
 libraries NativeCall is able to interface with are those written in C.
 Languages like Fortran and C++ require name mangling, which is
 compiler-specific and thus falls well beyond the scope of this specification.
@@ -53,7 +53,7 @@ compatible with the types specified in the next section.
     sub trait_mod:<is>(Routine $r, :$native!) is export(:DEFAULT, :traits) { ... }
 
 The C<is native> trait is the main gateway used to access C libraries. A
-routine with this trait applied will not be a normal Perl 6 callable, but will
+routine with this trait applied will not be a normal Raku callable, but will
 call into the function with the same name in the specified library.
 
 The library name passed to C<is native> is passed unmodified to
@@ -66,7 +66,7 @@ C<dlsym(RTLD_DEFAULT, symbol)> in C.
 Hypotheticals:
 
 =for item
-Perl 6 allows a greater range of characters in identifiers than C. Should we
+Raku allows a greater range of characters in identifiers than C. Should we
 look for cases where the identifier isn't legal in C?
 
 =for item
@@ -78,7 +78,7 @@ This is rather UNIX-centric. Other platforms may very well complicate things.
 
 Since all symbols in a C library share a single namespace with all other
 libraries, it is common practice to prefix externally visible symbols with a
-library prefix so as not to interfere with other libraries. In Perl 6 this may
+library prefix so as not to interfere with other libraries. In Raku this may
 be a nuisance, and the C<is symbol> trait lets a user specify a different
 symbol name to search for than the name of the sub.
 
@@ -111,14 +111,14 @@ the C<is native> trait; after all, all exported symbols are the same from the
 point of view of the linker: a pointer to something. The C<is symbol> and
 C<is encoding> (for strings) traits also apply to variables.
 
-=head2 Marshalling and demarshalling of Perl 6 data
+=head2 Marshalling and demarshalling of Raku data
 
-The raw internal representation of most Perl 6 objects can't be expected to
+The raw internal representation of most Raku objects can't be expected to
 work sensibly with native code. To specify how to marshal and demarshal
-complex Perl 6 objects, representation polymorphism is most frequently used,
+complex Raku objects, representation polymorphism is most frequently used,
 but some classes are provided for frequent use cases.
 
-For pointer types, the type object associated with the Perl 6 class represents
+For pointer types, the type object associated with the Raku class represents
 the null pointer.
 
 =head3 Numeric types
@@ -225,7 +225,7 @@ The C<CPointer> REPR enables types that are similar to C<OpaquePointer> in
 that they cannot be introspected or mutated, but different in that they can
 have methods. This makes it easy to interface with "object-oriented" C code
 that returns an opaque pointer handle that encapsulate the resources used by
-the library and lets us implement this naturally using Perl 6 OO.
+the library and lets us implement this naturally using Raku OO.
 
 A C<CPointer> object can not have attributes.
 
@@ -233,7 +233,7 @@ A C<CPointer> object can not have attributes.
 
     class CArray[::Type] does Positional[Type] is export(:DEFAULT, :types) { ... }
 
-General Perl 6 arrays support features such as laziness, which means that they
+General Raku arrays support features such as laziness, which means that they
 can not easily be marshalled into a C representation. Thus, NativeCall
 provides the CArray type which supports a set of array features compatible
 with marshalling to and from C. The C<Type> parameter is, of course, mandatory
@@ -246,19 +246,19 @@ the array. NativeCall will make no attempt to figure this out, and requests
 for array elements outside of the array is likely to result in death by
 segmentation fault.
 
-If the C<CArray> has been created in Perl 6, the bounds of the array are
+If the C<CArray> has been created in Raku, the bounds of the array are
 known, and operations can be bounds-checked and the array grown appropriately.
 Note, however, that growing an array may result in its C representation being
 moved to a different memory location. Thus, if a piece of C code has stored
 the location of an array and it is later on moved due to operations on the
-Perl side, strange bugs and segfaults are likely to ensue.
+Raku side, strange bugs and segfaults are likely to ensue.
 
 =head3 The C<CStruct> REPR
 
     class StructObject is repr('CStruct') { ... }
 
 Structs are an important part of most non-trivial C APIs; using the C<CStruct>
-REPR, arbitrary structs can be accessed just like ordinary Perl 6 classes.
+REPR, arbitrary structs can be accessed just like ordinary Raku classes.
 
 =head3 Callable objects
 
@@ -275,11 +275,11 @@ rather than parameters (note: callbacks returned from C NYI).
 Caveat emptor: This section, like the one on global variables, is all
 conjecture. Nothing is implemented.
 
-In Perl 6 the distinction between value type and reference is intrinsic to the
+In Raku the distinction between value type and reference is intrinsic to the
 type. In C, on the other hand, any type can be used both as a value and
 reference type, depending on how it's used. Thus, NativeCall needs some
 mechanism to duplicate this. One possible source of inspiration for this is
-C#. C# distinguishes between value and reference types similarly to Perl 6 and
+C#. C# distinguishes between value and reference types similarly to Raku and
 also has a well-supported foreign function interface.
 
 =head3 Varargs

--- a/S22-package-format.pod
+++ b/S22-package-format.pod
@@ -16,7 +16,7 @@ Synopsis 22: Distributions, Recommendations, Delivery and Installation
 Because many of the concepts used in this document may be overloaded by
 other concepts in the mind of the reader, it seems like a good idea to define
 some terminology first.  Please note that these definitions only apply within
-the context of Perl 6.
+the context of Raku.
 
 =head2 compilation unit
 
@@ -34,7 +34,7 @@ or more compilation units (each stored in a separate file), with any possibly
 associated files needed for execution.  For example:
 
   lib/JSON/Fast.pm6
-  lib/JSON/PurePerl.pm6
+  lib/JSON/PureRaku.pm6
 
 It has a name for identification, which may or may not coincide with the
 compilation units in the distribution.  An example of a distribution name:
@@ -56,7 +56,7 @@ C<-> for the filename of the archive, we are effectively disallowing an owner
 to upload a distribution for "JSON-Fast" and "JSON::Fast" at the same time.
 This seems unlikely to become a problem.
 
-A Perl 6 distribution B<must> contain a configuration file named C<META6.json>,
+A Raku distribution B<must> contain a configuration file named C<META6.json>,
 containing JSON-encoded information about the contents of the distribution.
 
 =head2 owner
@@ -122,21 +122,21 @@ the request.
 The recommendation manager is only used during the installation process of
 the distribution for a wanted compilation unit.
 
-A recommendation manager can be run by a community (like the current Perl 6
-ecosystem or the packages list for Perl 5 on CPAN), or by company (for use
+A recommendation manager can be run by a community (like the current Raku
+ecosystem or the packages list for Perl on CPAN), or by company (for use
 inside the company itself), or by any reviewing / grading service (for use
 by anybody wanting to use that service), or by any other person willing to
 put in the effort.
 
 A request for:
 
-  JSON::PurePerl
+  JSON::PureRaku
 
 would yield the identity:
 
   cpan:JRANDOM:JSON-Fast:1.23
 
-because the compilation unit C<JSON::PurePerl> is part of the C<JSON::Fast>
+because the compilation unit C<JSON::PureRaku> is part of the C<JSON::Fast>
 distribution.
 
 However, a request for:
@@ -159,14 +159,14 @@ source for bundling distributions in their specific packaging system.
 
 =head1 DISTRIBUTION
 
-A Perl 6 distribution consists of an archive of some form (presumably a
+A Raku distribution consists of an archive of some form (presumably a
 .tar.gz, .tar.bz2 or .zip file) which is expected to at least contain a file
 called "META6.json".  The existence of this file indicates that this
-distribution is a Perl 6 distribution.  This is important for those archive
+distribution is a Raku distribution.  This is important for those archive
 networks that also serve as a content-distribution system for other types
 of distributions (such as PAUSE / CPAN), so that they can adapt the processing
 of the contents, or decide to ignore any processing at all (such as CPAN-testers
-not being able to test Perl 6 distributions (yet)).
+not being able to test Raku distributions (yet)).
 
 =head2 META6.json
 
@@ -185,7 +185,7 @@ installed.  Specified as a version string.  So:
 
   "perl" : "6.d"
 
-would not allow installation on Perl version 6.c
+would not allow installation on Raku version 6.c
 
 =head3 name
 
@@ -228,7 +228,7 @@ available to be C<use>d.  For example:
 
   "provides" : {
     "JSON::Fast"     : "lib/JSON/Fast.pm6",
-    "JSON::PurePerl" : "lib/JSON/PurePerl.pm6"
+    "JSON::PureRaku" : "lib/JSON/PureRaku.pm6"
   }
 
 Please note that the filenames specified only indicate the names of the files
@@ -289,8 +289,8 @@ Please note that the C<use> strings of compilation units are specified.  It
 is the responsibility of the recommendation manager to turn these into
 identities of distributions that can be downloaded.
 
-Dependencies need not be Perl 6 only. By using the C<:from> adverb on the C<use>
-string, dependencies external to Perl 6 can be specified. These could be Perl 5
+Dependencies need not be Raku only. By using the C<:from> adverb on the C<use>
+string, dependencies external to Raku can be specified. These could be Perl
 modules like C<Mojolicious:from<Perl5>>. Two names are reserved:
 
 =head4 :from<bin>
@@ -431,10 +431,10 @@ will be disallowed when attempted to be loaded in the same lexical scope.
 An example of this would be:
 
   "excludes" : {
-    "JSON::PurePerl" : "JSON::Slow:auth<cpan:*>:ver(1..*)"
+    "JSON::PureRaku" : "JSON::Slow:auth<cpan:*>:ver(1..*)"
   }
 
-So, if a lexical scope loads C<JSON::PurePerl> from this distribution, then
+So, if a lexical scope loads C<JSON::PureRaku> from this distribution, then
 attempting to load C<JSON::Slow> will cause a Failure.  Please note that this
 has B<no> meaning for packagers: it is simply a way to provide a better error
 message if a collision of some sort will occur when both modules are loaded
@@ -579,7 +579,7 @@ possibly in parallel.
 
 =head3 hooks
 
-All files in this directory should contain executable Perl 6 code, to be
+All files in this directory should contain executable Raku6 code, to be
 executed at various stages of the install process of this distribution.
 
 =head2 Installation
@@ -681,7 +681,7 @@ Return L<CompUnit> candidates given the matching credentials.
 
 The simplest, default case for locating compilation units on a file system.
 The module name specified should directly map to a file, similar to how
-Perl 5 this does.  Mainly intended to be used in development situations
+Perl this does.  Mainly intended to be used in development situations
 to allow developers to have modules to be available without them having to be
 installed.
 
@@ -692,7 +692,7 @@ files in the right location.
 
 =head2 CompUnit::Repository::Installation
 
-The default case for installed compilation units.  Similar to the way Perl 5
+The default case for installed compilation units.  Similar to the way Perl
 installs modules, but with meta-information per object, rather than globally
 in a C<packlist>.  This should be used by installers such as C<panda>.
 

--- a/S24-testing.pod
+++ b/S24-testing.pod
@@ -29,7 +29,7 @@ Synopsis 24: Testing
 
 =head1 DESCRIPTION
 
-Perl 6 comes with a standard testing module, C<Test>. It is the testing module
+Raku comes with a standard testing module, C<Test>. It is the testing module
 used by the official spectest suite.
 
 The testing functions emit output conforming to the Test Anything

--- a/S26-documentation.pod
+++ b/S26-documentation.pod
@@ -1,7 +1,7 @@
 =begin pod
 
 =comment
-This file is deliberately specified in Perl 6 Pod format
+This file is deliberately specified in Raku Pod format
 
 =TITLE
 Synopsis 26 - Documentation
@@ -21,8 +21,8 @@ underlying document object model. Pod can be used for writing language
 documentation, for documenting programs and modules, as well as for
 other types of document composition.
 
-Pod is an evolution of Perl 5's L<I<Plain Ol' Documentation>|doc:perlpod>
-(POD) markup. Compared to POD, Perl 6's Pod is much more
+Pod is an evolution of Perl's L<I<Plain Ol' Documentation>|doc:perlpod>
+(POD) markup. Compared to POD, Raku's Pod is much more
 uniform, somewhat more compact, and considerably more expressive. The
 Pod dialect also differs in that it is a purely descriptive mark-up
 notation, with no presentational components.
@@ -33,7 +33,7 @@ notation, with no presentational components.
 Pod documents are specified using D<directives|directive>, which are
 used to declare configuration information and to delimit blocks of
 textual content. All Pod directives are considered to be special types
-of comments in Perl 6.
+of comments in Raku.
 
 Every directive starts either with an equals sign (C<=>) followed
 immediately by an identifier N<as specified in Synopsis 2>, or with
@@ -42,7 +42,7 @@ a C<#=> or C<#|> followed immediately by whitespace or an opening bracket.
 Directives that start with C<=> can be indented like the code they
 interleave, but their initial C<=> must still be the first non-whitespace
 character on their line. Directives that start with C<#=> or C<#|> can be placed
-anywhere that a Perl 6 comment can appear, though they are meaningful
+anywhere that a Raku comment can appear, though they are meaningful
 only in a subset of those places; see L<#Declarator blocks>.
 
 An indented Pod block is considered to have a I<virtual left margin>,
@@ -52,7 +52,7 @@ In other words, if a directive is indented from the left margin, the
 column at which the first character of its opening delimiter appears is
 thereafter considered the first column of the entire block's contents.
 
-As with Perl 6 heredocs, the virtual margin treats leading tabs as
+As with Raku heredocs, the virtual margin treats leading tabs as
 aligning to tabstops spaced every C<($?TABSTOP // 8)> characters.
 
 =head2
@@ -73,10 +73,10 @@ parsers still parse this text into the internal representation of the
 file, representing it as a C<Pod::Block::Ambient> block. Renderers
 will I<usually> ignore such blocks, but see L<#Aliases>.
 
-In Perl 5's POD format, once a POD directive is encountered, the parser
+In Perl's POD format, once a POD directive is encountered, the parser
 considers everything that follows to be POD, until an explicit C<=cut>
 directive is encountered, at which point the parser flips back to
-parsing ambient source code. The Perl 6 Pod format is different. All Pod
+parsing ambient source code. The Raku Pod format is different. All Pod
 directives have a defined terminator and the Pod parser always reverts to
 "ambient" at the end of each Pod directive or block. To cause the parser
 to remain in Pod mode, you must enclose the desired Pod region in a
@@ -97,7 +97,7 @@ C<pod> block:
 =head3 Delimited blocks
 
 Delimited blocks are bounded by C<=begin> and C<=end> markers, both of
-which are followed by a valid Perl 6 identifier, which is the
+which are followed by a valid Raku identifier, which is the
 D<typename> of the block. Typenames that are entirely lowercase (for
 example: C<=begin head1>) or entirely uppercase (for example: C<=begin
 SYNOPSIS>) are reserved.
@@ -105,7 +105,7 @@ SYNOPSIS>) are reserved.
 After the typename, the rest of the C<=begin> marker line is treated as
 configuration information for the block. This information is used in
 different ways by different types of blocks, but is always specified using
-Perl6-ish option pairs. That is, any of:
+raku-ish option pairs. That is, any of:
 
 =for table :nested
  Value is...       Specify with...       Or with...       Or with...
@@ -119,7 +119,7 @@ Perl6-ish option pairs. That is, any of:
 All option keys and values must, of course, be constants since Pod is a
 specification language, not a programming language. Specifically, option
 values cannot be closures. See Synopsis 2 for details of the various
-Perl 6 pair notations.
+Raku pair notations.
 
 The configuration section may be extended over subsequent lines by
 starting those lines with an C<=> in the first (virtual) column followed
@@ -129,7 +129,7 @@ The lines following the opening delimiter and configuration are the
 data or contents of the block, which continue until the block's matching
 C<=end> marker line. For most block types, these contents may be
 indented if you wish, without them being treated as L<code blocks|#Code
-blocks>. Unlike Perl 5, indented text is only treated as code within
+blocks>. Unlike Perl, indented text is only treated as code within
 C<=pod>, L<C<=nested>|#Nesting blocks>, L<C<=item>|#Lists>, C<=code>,
 and L<semantic|#Semantic blocks> blocks.
 
@@ -171,7 +171,7 @@ This is a universal feature of Pod.
 
 Note also that in the following specifications, a "blank line" is a line
 that is either empty or that contains only whitespace characters. That
-is, a blank line matches the Perl 6 pattern: C</^^ \h* $$/>. Pod uses
+is, a blank line matches the Raku pattern: C</^^ \h* $$/>. Pod uses
 blank lines as delimiters, rather than empty lines, to minimize unpleasant
 surprises when stray spaces or tabs mysteriously turn up in hitherto
 empty lines.
@@ -247,16 +247,16 @@ configuration is required, use a C<=for> or C<=begin>/C<=end> instead.
 
 The fourth form of Pod block differs from the first three in that it
 does not specify an explicit typename. Instead, it obtains its identity
-and purpose from the Perl 6 source code to which it is attached;
+and purpose from the Raku source code to which it is attached;
 specifically, from some nearby declarator.
 
-Declarator blocks are introduced by a special Perl comment: either C<#=>
+Declarator blocks are introduced by a special Raku comment: either C<#=>
 or C<#|>, which must be immediately followed by either by a space or an
 opening bracket. If followed by a space, the block is terminated by the
 end of line; if followed by one or more opening brackets, the block is
 terminated by the matching sequence of closing brackets.
 
-That is, declarator Pod blocks are syntactically like ordinary Perl 6
+That is, declarator Pod blocks are syntactically like ordinary Raku
 single-line comments and embedded comments. The general syntax is:
 
 =begin code :allow< R >
@@ -275,11 +275,11 @@ single-line comments and embedded comments. The general syntax is:
 
 =end code
 
-except that the bracketed forms may use I<any> valid Perl 6 bracket delimiter
+except that the bracketed forms may use I<any> valid Raku bracket delimiter
 (including repeated opening brackets), as described in Synopsis 2.
 
 Declarator Pod blocks must either precede or immediately follow a valid
-Perl 6 declarator, and are then said to be "attached" to it. They are
+Raku declarator, and are then said to be "attached" to it. They are
 primarily intended to simplify the documentation of code interfaces.
 
 Declarator blocks that start with C<#|> attach to the declarator immediately
@@ -649,7 +649,7 @@ be convenient to guide subsequent indentations. For example:
            V<=begin> pod :margin<|>
            |=head1 Hey Look: Indented Pod!
            |
-           |You can indent Pod in Perl 6
+           |You can indent Pod in Raku
            |which makes code look cleaner
            |when documentation is interspersed
            |
@@ -1526,12 +1526,12 @@ uppercase letters are reserved. See L<#Semantic blocks>.
 
 =head3 Pod comments
 
-All Pod blocks are intrinsically Perl 6 comments, but
+All Pod blocks are intrinsically Raku comments, but
 D<Pod comments|Pod comment> are comments that Pod renderers ignore too.
 That is, they are Pod blocks that are never to be rendered by any
 renderer. They are, of course, still included in any internal Pod
 representation, and are accessible via the Pod API...and via the
-C<$=pod> variable within a Perl 6 program.
+C<$=pod> variable within a Raku program.
 
 Comments are useful for meta-documentation (documenting the documentation):
 
@@ -1553,9 +1553,9 @@ and for temporarily removing parts of a document:
     B<=end comment>
 =end code
 
-Note that, since the Perl interpreter never executes embedded Pod
+Note that, since the Raku interpreter never executes embedded Pod
 blocks, C<comment> blocks can also be used as an alternative form of
-nestable block comments in Perl 6:
+nestable block comments in Raku:
 
 =begin code
     =begin comment
@@ -1583,8 +1583,8 @@ an C<=finish> block is in all other respects identical to a C<=pod> block.
 
 =head3 Data blocks
 
-Named Pod blocks whose typename is C<data> are the Perl 6 equivalent of
-the Perl 5 C<__DATA__> section. The difference is that C<=data> blocks are
+Named Pod blocks whose typename is C<data> are the Raku equivalent of
+the Perl C<__DATA__> section. The difference is that C<=data> blocks are
 just regular Pod blocks and may appear anywhere within a source file, and as
 many times as required.
 
@@ -1640,7 +1640,7 @@ C<=data> blocks are never rendered by the standard Pod renderers.
 All uppercase block typenames are reserved for specifying standard
 documentation, publishing, source components, or meta-information of a
 compunit it needs to be able to be selected for loading. In particular, all the
-standard components found in Perl and manpage documentation have
+standard components found in Raku and manpage documentation have
 reserved uppercase typenames.
 
 Standard semantic blocks include:
@@ -1731,9 +1731,9 @@ C<=SYNOPSIS> block of the preceding example might be rendered like so:
 B<3.E<nbsp;nbsp>I<Synopsis>>
 
 =begin code
-    use Perl6::Magic::Parser;
+    use Raku::Magic::Parser;
 
-    my $rep = Perl6::Magic::Parser.parse($fh, :all_pod);
+    my $rep = Raku::Magic::Parser.parse($fh, :all_pod);
 =end code
 =end nested
 
@@ -1767,7 +1767,7 @@ characters that are longer than the delimiters:
         These are errors...
 
     C< $fooB«<<»barB«>>» >
-    The Perl 5 heredoc syntax was: C< B«<<»END_MARKER >
+    The Perl heredoc syntax was: C< B«<<»END_MARKER >
 =end code
 
 You I<can> use sequences of angles that are the same length as
@@ -1780,14 +1780,14 @@ If you need an unbalanced angle, either use different delimiters:
 
 =begin code :allow<B>
     CB<«>$foo < $barB<»>
-    The Perl 5 heredoc syntax was: CB<«> <<END_MARKER B<»>
+    The Perl heredoc syntax was: CB<«> <<END_MARKER B<»>
 =end code
 
 or delimiters with more consecutive angles than your text contains:
 
 =begin code :allow<B>
     CB«<<»$foo < $barB«>>»
-    The Perl 5 heredoc syntax was: CB«<<<» <<END_MARKER B«>>>»
+    The Perl heredoc syntax was: CB«<<<» <<END_MARKER B«>>>»
 =end code
 
 A formatting code ends at the matching closing angle bracket(s), or at
@@ -1887,7 +1887,7 @@ L<reconfigure|#Block pre-configuration> it:
 =begin code :allow<B>
     =begin para
     B<=config C<> :allow<E I>>
-    Perl 6 makes extensive use of the C<B<E<laquo>>> and C<B<E<raquo>>>
+    Raku makes extensive use of the C<B<E<laquo>>> and C<B<E<raquo>>>
     characters, for example, in a hash look-up:
     C<%hashB<I<E<laquo>>>keyB<I<E<raquo>>>>
     =end para
@@ -1961,11 +1961,11 @@ For example:
     to quit all applications.
 =end code
 
-In Perl 5 POD, the C<Z<>> code was widely used to break up text that would
+In Perl POD, the C<Z<>> code was widely used to break up text that would
 otherwise be considered mark-up:
 
 =begin code :allow<B>
-    In Perl 5 POD, the ZB<Z<>><> code was widely used to break up text
+    In Perl POD, the ZB<Z<>><> code was widely used to break up text
     that would otherwise be considered mark-up.
 =end code
 
@@ -1973,7 +1973,7 @@ That technique still works, but it's now easier to accomplish the same goal
 using a verbatim formatting code:
 
 =begin code :allow<B>
-    In Perl 5 POD, the B«V<V<Z<>>>» code was widely used to break up text
+    In Perl POD, the B«V<V<Z<>>>» code was widely used to break up text
     that would otherwise be considered mark-up.
 =end code
 
@@ -1981,7 +1981,7 @@ Moreover, the C<C<>> code automatically treats its contents as being
 verbatim, which often eliminates the need for the C<V<>> as well:
 
 =begin code :allow<B>
-    In Perl 5 POD, the B«V<C<Z<>>>» code was widely used to break up text
+    In Perl POD, the B«V<C<Z<>>>» code was widely used to break up text
     that would otherwise be considered mark-up.
 =end code
 
@@ -2279,7 +2279,7 @@ For example:
     laid out by A<VENDOR>, as specified at A<TERMS_URL>.
 =end code
 
-Any compile-time Perl 6 object that starts with a sigil is automatically
+Any compile-time Raku object that starts with a sigil is automatically
 available within an alias placement as well. Unless the object is already
 a string type, it is converted to a string during document-generation by
 implicitly calling C<.perl> on it.
@@ -2338,31 +2338,31 @@ Pod document, specify the required D<entity|entities> using the C<E<>> code.
 If the C<E<>> contains a number, that number is treated as the decimal
 Unicode value for the desired code point. For example:
 
-    Perl 6 makes considerable use of E<171> and E<187>.
+    Raku makes considerable use of E<171> and E<187>.
 
 You can also use explicit binary, octal, decimal, or hexadecimal numbers
-(using the Perl 6 notations for explicitly based numbers):
+(using the Raku notations for explicitly based numbers):
 
-    Perl 6 makes considerable use of E<0b10101011> and E<0b10111011>.
-    Perl 6 makes considerable use of E<0o253> and E<0o273>.
-    Perl 6 makes considerable use of E<0d171> and E<0d187>.
-    Perl 6 makes considerable use of E<0xAB> and E<0xBB>.
+    Raku makes considerable use of E<0b10101011> and E<0b10111011>.
+    Raku makes considerable use of E<0o253> and E<0o273>.
+    Raku makes considerable use of E<0d171> and E<0d187>.
+    Raku makes considerable use of E<0xAB> and E<0xBB>.
 
 If the C<E<>> contains anything that is not a number, the contents are
 interpreted as a Unicode character name (which is always uppercase), or
 else as an HTML5 named character reference. For example:
 
-    Perl 6 makes considerable use of E<LEFT DOUBLE ANGLE BRACKET>
+    Raku makes considerable use of E<LEFT DOUBLE ANGLE BRACKET>
     and E<RIGHT DOUBLE ANGLE BRACKET>.
 
 or, equivalently:
 
-    Perl 6 makes considerable use of E<laquo> and E<raquo>.
+    Raku makes considerable use of E<laquo> and E<raquo>.
 
 Multiple consecutive entities (in any format) can be specified in a
 single C<E<>> code, separated by semicolons:
 
-    Perl 6 makes considerable use of E<LEFT DOUBLE ANGLE BRACKET;hellip;0xBB>.
+    Raku makes considerable use of E<LEFT DOUBLE ANGLE BRACKET;hellip;0xBB>.
 
 
 =head3 Indexing terms
@@ -2422,8 +2422,8 @@ Anything enclosed in an C<N<>> code is an inline B<note>.
 For example:
 
 =begin code :allow<B>
-    Use a C<for> loop instead.B<N<The Perl 6 C<for> loop is far more
-    powerful than its Perl 5 predecessor.>> Preferably with an explicit
+    Use a C<for> loop instead.B<N<The Raku C<for> loop is far more
+    powerful than its Perl predecessor.>> Preferably with an explicit
     iterator variable.
 =end code
 
@@ -2442,7 +2442,7 @@ and later:
 B<Footnotes>
 
 =para
-E<dagger> The Perl 6 C<for> loop is far more powerful than its Perl 5
+E<dagger> The Raku C<for> loop is far more powerful than its Perl
 predecessor.
 =end nested
 
@@ -2516,7 +2516,7 @@ byte of the file. For example, at the start of a ShiftJIS-encoded file
 you can specify C<=encoding ShiftJIS> in the ShiftJIS encoding.
 
 An C<=encoding> directive affects any ambient code between the Pod
-as well. That is, Perl 6 uses C<=encoding> directives to determine the
+as well. That is, Raku uses C<=encoding> directives to determine the
 encoding of its source code as well as that of any documentation.
 
 Note that C<=encoding> is a fundamental Pod directive, like C<=begin> or
@@ -2627,7 +2627,7 @@ identifier (which is usually specified in uppercase, though this is
 certainly not mandatory). The second argument consists of one or more
 lines of replacement text.
 
-This creates a lexically scoped Perl 6 macro that can be invoked during
+This creates a lexically scoped Raku macro that can be invoked during
 document generation by placing the identifier (i.e. the first argument
 of the alias) in an C<A<>> formatting code. This formatting code is then
 replaced by the text returned by new macro.
@@ -2692,7 +2692,7 @@ and some portion of the following code is used as the value returned by the
 alias macro.
 
 Note that the code block following the C<=alias> line is still treated
-as real code by the Perl 6 parser, but its contents are I<also> used to
+as real code by the Raku parser, but its contents are I<also> used to
 create the replacement macro of the alias. This allows the developer to
 reproduce chunks of actual source code directly in the documentation,
 without having to copy it.
@@ -2777,8 +2777,8 @@ attribute. By default, handles are opened to the file "C<db.log>".
 
 =head1 How Pod is parsed and processed
 
-Pod is just a collection of specialized forms of Perl 6 comment. Every
-Perl 6 implementation must provide a special command-line flag that
+Pod is just a collection of specialized forms of Raku comment. Every
+Raku implementation must provide a special command-line flag that
 locates, parses, and processes Pod to produce documentation. That flag
 is K<--doc>.
 
@@ -2790,7 +2790,7 @@ Hence, to read Pod documentation you would type things like:
 
     perl --doc  ./lib/My/Module.pm
 
-When the Perl 6 interpreter is run in this mode, it sets the compiler
+When the Raku interpreter is run in this mode, it sets the compiler
 hint C<$?DOC> to true. If the K<--doc> flag is given a value, that value
 (with a C<but true> added) is placed in C<$?DOC>. This can be used to
 specify, for example, the output format desired:
@@ -2815,7 +2815,7 @@ the C<$=pod> tree, and any C<DOC> blocks that have loaded Pod-related
 handler code.
 
 Because the conversion of documentation is just a variation on the
-standard Perl 6 compilation process, the processing of any given file of
+standard Raku compilation process, the processing of any given file of
 Pod can be modified from within that file itself by the appropriate
 insertion of C<DOC> blocks. For example:
 
@@ -2856,7 +2856,7 @@ long as you remember to exit before the default C<DOC INIT> can run:
 The idea is that developers will be able to add their own documentation
 mechanisms simply by loading a module (via a C<DOC use>) to augment or
 override the default documentation behaviour. Such mechanisms can then
-be built using code written in standard Perl 6 that accesses C<$=pod>,
+be built using code written in standard Raku that accesses C<$=pod>,
 as well as using the C<.WHY> and C<.WHEREFORE> introspection methods of
 any constructs that have attached Pod blocks.
 
@@ -2915,7 +2915,7 @@ create a self-converting documentation file like so:
     C<=para>            Ordinary paragraph
     C<=pod>             No "ambient" blocks inside
     C<=table>           Simple rectangular table
-    C<=data>            Perl 6 data section
+    C<=data>            Raku data section
     C<=finish>          No ambient blocks after this point
     C<=>R<RESERVED>     Semantic blocks (C<=SYNOPSIS>, C<=BUGS>, etc.)
     C<=>R<Typename>     User-defined block

--- a/S28-special-names.pod
+++ b/S28-special-names.pod
@@ -17,13 +17,13 @@
 
 This document serves as a collection point
 for what is known about special variables
-in Perl 6 and correlates them with the changes from Perl 5.
+in Raku and correlates them with the changes from Perl.
 
-If you are trying to find the Perl 6 equivalent of a Perl 5 special
-variable you know, try searching this file for the Perl 5 version.
+If you are trying to find the Raku equivalent of a Perl special
+variable you know, try searching this file for the Perl version.
 Each main entry is followed by a note containing the corresponding
-Perl 5 variable(s). The list of main entries is also followed by
-a table showing the 5 and 6 variables side-by-side.
+Perl variable(s). The list of main entries is also followed by
+a table showing the Perl and Raku variables side-by-side.
 
 =head2 Overview
 
@@ -105,11 +105,11 @@ be fleshed out in S26.
  $*KERNEL                Systemic     # operating system running under
  $*OUT             S16   IO::Handle   # Standard output handle
  $?PACKAGE         S02   Package      # current package
- $?PERL            S02   Systemic     # Which Perl am I compiled for?
- $*PERL            S02   Systemic     # perl version running under
+ $?RAKU            S02   Systemic     # Which Raku am I compiled for?
+ $*RAKU            S02   Systemic     # Raku version running under
  $*PID                   Int          # system process id
  $=pod             S02                # POD6 data
- $*PROGRAM         S19   IO::Path     # location of the Perl program being executed
+ $*PROGRAM         S19   IO::Path     # location of the Raku program being executed
  %*PROTOCOLS       S16   Hash of Method # Stores the methods needed for the uri() function
  ::?ROLE                 Str          # current role (as package or type name)
  $?ROLE            S02   Role         # current role
@@ -148,11 +148,11 @@ in order to have a unique name.
         ...
     }
 
-=head3 Perl 5 to Perl 6 special variable translation
+=head3 Perl to Raku special variable translation
 
 If a column has a "-" in it, it means that item is unavailable in that version of Perl.
 
- Perl 5              Perl 6         Comment
+ Perl                Raku           Comment
  -----------         -----------    -----------------------
  STDIN               $*IN           See S16; actual variable is $PROCESS::IN
  STDOUT              $*OUT          See S16; actual variable is $PROCESS::OUT
@@ -310,9 +310,9 @@ The name of the compilation stage to produce pre-compiled module files
 
 =back
 
-=head3 $?PERL / $*PERL
+=head3 $?RAKU / $*RAKU
 
-Contains a C<Perl> class instance that does C<Systemic>.  It further
+Contains a C<Raku> class instance that does C<Systemic>.  It further
 provides the following methods:
 
 =over
@@ -335,15 +335,15 @@ provides the following methods:
 
 =item release
 
-The release information of this version of Perl.
+The release information of this version of Raku.
 
 =item build-date
 
-The C<DateTime> this version of Perl was built.
+The C<DateTime> this version of raku was built.
 
 =item codename
 
-The codename of this version of Perl.
+The codename of this version of Raku.
 
 =back
 
@@ -359,9 +359,9 @@ The $?LANG and $*LANG variables are also confusing (both in S02).
 
 =head3 Form.pm
 
-These go in the Perl 5 to Perl 6 conversion table:
+These go in the Perl to Raku conversion table:
 
- Perl 6  Perl 5
+ Raku    Perl  
  ------  -----------------------------------------
  -       $%  $FORMAT_PAGE_NUMBER
  -           HANDLE->format_page_number(EXPR)

--- a/S29-functions.pod
+++ b/S29-functions.pod
@@ -15,11 +15,11 @@ The document is a draft.
 
 =head1 Notes
 
-In Perl 6, all builtin functions belong to a named package (generally a
+In Raku, all builtin functions belong to a named package (generally a
 class or role). Not all
 functions are guaranteed to be imported into the CORE scope.
 In addition, the list of functions imported into C<CORE> will be
-subject to change with each release of Perl. Authors wishing to
+subject to change with each release of Raku. Authors wishing to
 "Future Proof" their code should either specifically import the
 functions they will be using, or always refer to the functions by their
 full name.
@@ -27,8 +27,8 @@ full name.
 After 6.0.0 comes out, global aliases will not be removed lightly,
 and will never be removed at all without having gone through a
 deprecation cycle of at least a year.  In any event, you can specify
-that you want the interface for a particular version of Perl, and
-that can be emulated by later versions of Perl to the extent that
+that you want the interface for a particular version of Raku, and
+that can be emulated by later versions of Raku to the extent that
 security updates allow.
 
 Where code is given here, it is intended to define semantics, not to
@@ -89,7 +89,7 @@ the information on how two things compare relative to each other.
 
 A closure with arity of 2, which for ordering returns
 negative/zero/positive, signaling the first argument should
-be before/tied with/after the second. aka "The Perl 5 way".
+be before/tied with/after the second. aka "The Perl way".
 
 For equivalence the closure returns either not 0 or 0 indicating
 if the first argument is equivalent or not to the second.
@@ -98,8 +98,8 @@ if the first argument is equivalent or not to the second.
 
 A closure with arity of 1, which returns the "key" by which
 to compare.  Values are compared using C<cmp> for orderings
-and C<eqv> for equivalences, which in Perl 6 do different
-comparisons depending on the types.  (To get a Perl 5 string
+and C<eqv> for equivalences, which in Raku do different
+comparisons depending on the types.  (To get a Perl string
 ordering you must compare with C<leg> instead.)
 
 Internally the result of the KeyExtractor on a value should
@@ -170,14 +170,14 @@ location of the C<EVAL> call.
 
 Returns whatever C<$code> returns, or fails when the compilation fails.
 
-Note that unlike in Perl 5's C<eval>, C<EVAL> does not catch any exceptions or control
+Note that unlike in Perl's C<eval>, C<EVAL> does not catch any exceptions or control
 exceptions.
 
 =item EVALFILE
 
- multi EVALFILE (Str $filename ; Grammar :$lang = Perl6)
+ multi EVALFILE (Str $filename ; Grammar :$lang = Raku)
 
-Behaves like, and replaces Perl 5 C<do EXPR>, with optional C<$lang>
+Behaves like, and replaces Perl C<do EXPR>, with optional C<$lang>
 support.
 
 =item exit
@@ -212,7 +212,7 @@ to support sub-second resolutions if that is at all possible.  You may pass
 any of C<Int>, C<Num>, C<Rat>, or C<Duration> types as an argument, since those
 all do C<Real>, but regardless of which type you use, they are always scaled to
 seconds.  (An implementation is allowed to provide access to a platform-specific
-function based on, say, nanoseconds, but Perl 6 does not presume to know
+function based on, say, nanoseconds, but Raku does not presume to know
 how much resolution clocks will have in the future, so requires everything to
 be specified in fractional seconds.)
 
@@ -416,7 +416,7 @@ see
 
 and such.
 
-Replaces Perl 5 C<hex> and C<oct>.
+Replaces Perl C<hex> and C<oct>.
 
 
 =back
@@ -455,7 +455,7 @@ appropriate text format (e.g. "10.1.2.3" for an IPV4 address).
 The optional C<type> adverb can be passed when resolving a hostname,
 and will filter the result to only those addresses that are of
 the appropriate address family. This feature may be supported by
-the underlying operating system, or Perl may emulate it.
+the underlying operating system, or Raku may emulate it.
 
 Examples:
 
@@ -558,9 +558,9 @@ replaces the currently running program in memory.
 
 =head2 Concurrency
 
-There are higher-level models of concurrency management in Perl (see
+There are higher-level models of concurrency management in Raku (see
 L<S17/Concurrency>). These functions are simply the lowest level
-tools
+tools.
 
 =over
 
@@ -723,7 +723,7 @@ These functions are exported into the default namespace
 
 =head2 Non-default Functions
 
-These functions which existed in Perl 5 still exist but are not part of the default
+These functions which existed in Perl still exist but are not part of the default
 namespace any more.
 
 =head3 Container
@@ -787,7 +787,7 @@ Does a floating point modulo operation, i.e. 5.5 % 1 == 0.5 and 5 % 2.5 == 0.
 Dumped.  Restoring from core dumps is in any event not very useful on modern
 virtual-memory operating systems.  Startup acceleration should be accomplished
 using a precompiler of some kind (details will be very implementation specific),
-or a pre-forking daemon such as Perl 5's App::Persistent (which will be an
+or a pre-forking daemon such as Perl's App::Persistent (which will be an
 external module when it is ported).
 
 =item each
@@ -812,7 +812,7 @@ The NameServices role in S16 covers most of these.
 
 =item length()
 
-This word is banned in Perl 6.  You must specify units.  In practice, this probably means
+This word is banned in Raku.  You must specify units.  In practice, this probably means
 you want Str.chars(), although it could be Str.bytes(), or even something else.  See
 S32-setting-library/String for details.
 
@@ -845,7 +845,7 @@ that speaks the language of a specific shell.
 
 =item pos
 
-There is no C<pos> function in Perl 6 because that would not allow a string
+There is no C<pos> function in Raku because that would not allow a string
 to be shared among threads.  Generally you want to use C<$/.to> for that now,
 or keep your own position variable as a lexical.
 
@@ -857,9 +857,9 @@ or keep your own position variable as a lexical.
 =item ref
 
 There is no ref() any more, since it was almost always used to get
-the type name in Perl 5.  If you really want the type name, you can
-use C<$var.WHAT.perl>.  If you really want P5 ref
-semantics, use C<Perl5::p5ref>.
+the type name in Perl.  If you really want the type name, you can
+use C<$var.WHAT.raku>.  If you really want P5 ref
+semantics, use C<Perl::p5ref>.
 
 But if you're just wanting to test against a type, you're likely better off
 performing an C<isa> or C<does> or C<can>, or just C<$var ~~ TYPE>.
@@ -920,7 +920,7 @@ See Exegesis 7.
 
 =head3 Keywords
 
-The following were listed in Perl 5's perlfunc, but should now be considered keywords
+The following were listed in Perl's perlfunc, but should now be considered keywords
 rather than functions.
 
 last, my, next, no, our, package, return, sub, use

--- a/S31-pragmatic-modules.pod
+++ b/S31-pragmatic-modules.pod
@@ -16,7 +16,7 @@ The document is a draft.
 
 =head1 Overview
 
-It is a general policy in Perl 6 that any pragma designed to influence
+It is a general policy in Raku that any pragma designed to influence
 the surface behavior of a keyword is identical to the keyword itself, unless
 there is good reason to do otherwise.  On the other hand, pragmas designed
 to influence deep semantics should not be named identically, though of

--- a/S32-setting-library/Basics.pod
+++ b/S32-setting-library/Basics.pod
@@ -40,7 +40,7 @@ The following are defined in the C<Mu> class:
 C<defined> returns true if the parameter has a value and that value is
 considered defined by its type, otherwise false is returned.
 
-Same as Perl 5, only takes extra optional argument to ask if value is defined
+Same as Perl, only takes extra optional argument to ask if value is defined
 with respect to a particular role:
 
   defined($x, SomeRole);

--- a/S32-setting-library/Containers.pod
+++ b/S32-setting-library/Containers.pod
@@ -241,7 +241,7 @@ This takes the array C<@coworkers>, checks every element to see
 which ones return true for the C<.is_friend> method, and stores
 the resulting sequence's values into C<@friends>.
 
-Note that, unlike in Perl 5, a comma is required after the C<Matcher>
+Note that, unlike in Perl, a comma is required after the C<Matcher>
 in the multi form.
 
 Note that C<grep> is an implicit loop, so C<next> and C<last> without

--- a/S32-setting-library/Exception.pod
+++ b/S32-setting-library/Exception.pod
@@ -169,8 +169,8 @@ Thrown when C<chmod> fails.
         method message() { "$.feature is not yet implemented. Sorry. " }
     }
 
-For errors that stem from incomplete implementations of the Perl 6 language.
-A full Perl 6.0 implementation should not throw such errors.
+For errors that stem from incomplete implementations of the Raku language.
+A full Raku implementation should not throw such errors.
 
 =head2 X::AdHoc
 
@@ -522,13 +522,13 @@ Common role for all syntax errors.
 
 =head3 X::Syntax::Obsolete
 
-Thrown when obsolete (mostly Perl 5) syntax is detected.
+Thrown when obsolete (mostly Perl) syntax is detected.
 
     role X::Syntax::Obsolete does X::Syntax {
         has $.old;
         has $.replacement; # cannot call it 'new',
                            # would collide with constructor
-        has $.when = 'in Perl 6';
+        has $.when = 'in Raku';
         method message() {
             "Unsupported use of $.old; $.when please use $.replacement";
         }
@@ -563,10 +563,10 @@ Thrown when a syntax is used which is reserved for future expansion.
 
 =head3 X::Syntax::P5
 
-Thrown when some piece of syntax is clearly Perl 5, not Perl 6.
+Thrown when some piece of syntax is clearly Perl, not Raku.
 
     my class X::Syntax::P5 does X::Syntax {
-        method message() { 'This appears to be Perl 5 code' }
+        method message() { 'This appears to be Perl code' }
     }
 
 =head3 X::Syntax::NegatedPair

--- a/S32-setting-library/IO.pod
+++ b/S32-setting-library/IO.pod
@@ -263,7 +263,7 @@ directory does not exist, or is not a directory, or is not readable.
 Please note that this directory has B<no> connection with whatever the
 operating system thinks is the current working directory.  The value of
 C<$*CWD> just will always be prepended to any relative paths in any file
-operation in Perl 6.
+operation in Raku.
 
 Also note that you can use C<chdir> to set similar dynamic variables, like
 C<$*TMPDIR> and C<$*HOME> this way:
@@ -381,7 +381,7 @@ dynamic variable.  So typically, you would call methods on that:
 
   my $cleanpath = $*SPEC.canonpath("a/.//b/")  # gives "a/b"
 
-This set of modules was inspired by Perl 5's C<File::Spec>.  An implementation
+This set of modules was inspired by Perl's C<File::Spec>.  An implementation
 may choose to inherit from C<IO::Spec>, or any of its subclasses, if that
 helps in avoiding code duplication.
 
@@ -1668,13 +1668,13 @@ If set to nonzero, forces a flush right away and after every write
 or print on the currently selected output channel.
 Default is 0 (regardless of whether the channel is really buffered
 by the system or not;
-C<$OUT_FH.autoflush> tells you only whether you've asked Perl
+C<$OUT_FH.autoflush> tells you only whether you've asked Raku
 explicitly to flush after each write).
 C<$*OUT> will typically be line buffered if output is to the
 terminal and block buffered otherwise.
 Setting this variable is useful primarily when you are
 outputting to a pipe or socket,
-such as when you are running a Perl program under rsh
+such as when you are running a Raku program under rsh
 and want to see the output as it's happening.
 This has no effect on input buffering.
 
@@ -1767,7 +1767,7 @@ constructor on that type, and passing in the appropriate uri.
 
 =head1 AUTHORS
 
-    The authors of the related Perl 5 docs
+    The authors of the related Perl docs
     Rod Adams <rod@rodadams.net>
     Larry Wall <larry@wall.org>
     Aaron Sherman <ajs@ajs.com>

--- a/S32-setting-library/Numeric.pod
+++ b/S32-setting-library/Numeric.pod
@@ -146,7 +146,7 @@ A base C<10> logarithm, otherwise identical to C<log>.
 
 Pseudo random number in range C<< 0 ..^ 1 >>.  That is, C<0> is
 theoretically possible, while C<1> is not.  Note that there is no
-unary C<rand> function in Perl 6, but there is a C<rand> method.
+unary C<rand> function in Raku, but there is a C<rand> method.
 For picking a random integer you probably want
 to use something like C<(1..6).pick> instead.
 
@@ -215,7 +215,7 @@ C<Real> types try to emulate that property, it is desirable that any two
 C<Real> types be mutually compatible, even if they are not aware of each other.  The
 current proposal requires you to define a C<Bridge> method in your C<Real> type, which
 converts your type into a neutral C<Real> type by restating it in terms of the fundamental
-Perl 6 types and calling C<Bridge> on them.  This then makes the default C<Real> methods
+Raku types and calling C<Bridge> on them.  This then makes the default C<Real> methods
 and operators all work with your C<Real> type.  While the name of this method may changed,
 it is hoped that something like this will remain in the spec.
 
@@ -300,7 +300,7 @@ is equal to 0, or undefined when the value passed is undefined.
 
 Seed the generator C<rand> uses. C<$seed> defaults to some combination
 of various platform dependent characteristics to yield a non-deterministic seed.
-Note that you get one C<srand()> for free when you start a Perl program, so
+Note that you get one C<srand()> for free when you start a Raku program, so
 you I<must> call C<srand()> yourself if you wish to specify a deterministic seed
 (or if you wish to be differently nondeterministic).
 

--- a/S32-setting-library/Rules.pod
+++ b/S32-setting-library/Rules.pod
@@ -32,7 +32,7 @@ Regex objects are created through the syntax described in S05:
     regex { ... }
 
 They can be stored in variables for later use, as with the C<qr//> syntax
-in Perl 5.
+in Perl.
 
 =over
 

--- a/S32-setting-library/Str.pod
+++ b/S32-setting-library/Str.pod
@@ -79,7 +79,7 @@ leaving the rest of the characters unchanged, then returns the
 modified string.  If there is no titlecase mapping for the first
 character, the entire string is returned unchanged.  In any case,
 this function never changes any character after the first.  (It
-is like the old Perl 5 C<ucfirst> function in that respect.)
+is like the old Perl C<ucfirst> function in that respect.)
 
 =item tclc
 
@@ -95,7 +95,7 @@ the characters to lowercase, then returns the modified string.
                           :$where = True --> Str) is export
 
 Performs a substitutional mapping of each word in the string,
-defaulting to the C<tclc> mapping.  Words are defined as Perl 6
+defaulting to the C<tclc> mapping.  Words are defined as Raku
 identifiers, hence admit hyphens and apostrophes when followed
 by a letter.  (Note that trailing apostrophes don't matter when
 casemapping.)  The following should have the same result:
@@ -137,7 +137,7 @@ Has the effect of making the case of the string match the marking pattern in C<$
 
 =item length
 
-This method does not exist in Perl 6. You must use either C<chars> or C<codes>,
+This method does not exist in Raku. You must use either C<chars> or C<codes>,
 depending on what kind of count you need.
 
 =item chars
@@ -212,8 +212,8 @@ In the pairwise mode, each key must contain a single C<< <group> >> or
 C<< <specifier> >>, and the values must be either scalar arguments or
 arrays.
 
-[ Note: Need more documentation and need to figure out what Perl 5 things
-        no longer make sense. Does Perl 6 need any extra formatting
+[ Note: Need more documentation and need to figure out what Perl things
+        no longer make sense. Does Raku need any extra formatting
         features? -ajs ]
 
 [I think pack formats should be human readable but compiled to an
@@ -264,7 +264,7 @@ into individual characters. (See below.)
 If the C<:all> adverb is supplied to the string delimiter form, the delimiter
 will be returned in alternation with the split values. In C<Regex> delimiter
 form, the delimiters are returned as C<Match> objects in alternation with the
-split values. Unlike with Perl 5, if the delimiter contains multiple captures
+split values. Unlike with Perl, if the delimiter contains multiple captures
 they are returned as submatches of single C<Match> object. (And since C<Match>
 does C<Capture>, whether these C<Match> objects eventually flatten or not
 depends on whether the expression is bound into a list or slice context.)
@@ -394,7 +394,7 @@ Compatibility:
     O   a synonym for %o
     F   a synonym for %f
 
-Perl 5 (non-)compatibility:
+Perl (non-)compatibility:
 
     n   produces a runtime exception
     p   produces a runtime exception

--- a/S32-setting-library/Temporal.pod
+++ b/S32-setting-library/Temporal.pod
@@ -13,20 +13,20 @@ Synopsis 32: Setting Library - Temporal
 
 =head1 Time and time again
 
-Two chief aspects of a Perl 6 synopsis seem to contribute to it having
+Two chief aspects of a Raku synopsis seem to contribute to it having
 some extra volatility: how far it sits from the rest of the data model
 of the language, and how everyday the topic in question is. C<S32> has
 always been volatile for these reasons; C<S32::Temporal> doubly so.
 
 The truth is that while there are many interests to satisfy in the case
 of a C<Temporal> module, and many details to take into account, there's
-also the danger of putting too much in. Therefore, Perl 6's C<Temporal>
+also the danger of putting too much in. Therefore, Raku's C<Temporal>
 module takes the C<DateTime> module on CPAN as a starting point, adapts
-it to the Perl 6 OO system, and boils it down to bare essentials.
+it to the Raku OO system, and boils it down to bare essentials.
 
-One of the unfortunate traditions that Perl 6 aims to break is that of
+One of the unfortunate traditions that Raku aims to break is that of
 having a set of "core" modules which could better serve the community on
-CPAN than in the Perl core. For this reason, this module doesn't handle
+CPAN than in the Raku core. For this reason, this module doesn't handle
 all the world's time zones, locales, date formatters or calendars.
 Instead, it handles a number of "natural" operations well enough for
 most people to be happy, and shows how those who want more than that can
@@ -37,7 +37,7 @@ the core.
 Note that in this document, the term "POSIX time" means the number of
 seconds since midnight UTC of 1 January 1970, not counting leap seconds.
 This is the same as the output of the ISO C C<time> function.
-Unlike in Perl 5, C<time> does not return fractional seconds, since C<POSIX>
+Unlike in Perl, C<time> does not return fractional seconds, since C<POSIX>
 does not define the concept during leap seconds.  You want
 to use C<now> for that instead.
 
@@ -282,7 +282,7 @@ The C<Str> method returns a string of the form 'yyyy-mm-dd'.
 The authors of the current rewrite want to mention, with thanks, the
 indirect contribution made by the previous authors:
 
-    The authors of the related Perl 5 docs
+    The authors of the related Perl docs
     Rod Adams <rod@rodadams.net>
     Larry Wall <larry@wall.org>
     Aaron Sherman <ajs@ajs.com>

--- a/S99-glossary.pod
+++ b/S99-glossary.pod
@@ -11,11 +11,11 @@ Synopsis 99: Glossary
     Last Modified: 26 Feb 2015
     Version: 8
 
-This document tries to define many of the terms used within the Perl 6
+This document tries to define many of the terms used within the Raku
 community.  It does not have an L</apocalypse> or L</exegesis
 predecessor>.  It is intended as both a quick introduction to terms
 used on the L</#perl6> L</channel> on L</freenode>, as well as a more
-permanent, and deeper source of explanations in the context of Perl 6.
+permanent, and deeper source of explanations in the context of Raku.
 
 If you, as a reader, miss a term in a glossary, just add the term with the
 explanation.  Or if you are not sure what the missing term means, just add a
@@ -27,7 +27,7 @@ the explanation later for you and everybody else.
 =head2 Abstract class
 
 An abstract L</class> defines the L</interface> of a class. Its L</method>s are left
-undefined. In Perl 6, abstract classes is one of the related abstractions implemented as
+undefined. In Raku, abstract classes is one of the related abstractions implemented as
 L</role>s.
 
 =head2 ack
@@ -44,7 +44,7 @@ an AST you can call "made" or "ast".  See L<S05-regex/Action objects>.
 
 =head2 advent calendar
 
-Articles about Perl 6 for every days of December before Christmas.
+Articles about Raku for every days of December before Christmas.
 At L<https://perl6advent.wordpress.com/>.
 
 
@@ -165,12 +165,12 @@ L</Parrot>.
 =head2 Bailador
 
 Spanish for "dancer", The Bailador module
-(L<https://github.com/tadzik/Bailador/>) is a port of Perl 5's Dancer web
+(L<https://github.com/tadzik/Bailador/>) is a port of Perl's Dancer web
 framework (L<http://perldancer.org/>).
 
 =head2 bare string
 
-A non-quoted alphanumeric string. In Perl 6, only allowed at the left of a
+A non-quoted alphanumeric string. In Raku, only allowed at the left of a
 L</fat comma>.
 
 =head2 biab
@@ -184,7 +184,7 @@ or L</postcircumfix>.
 
 =head2 blast
 
-"B<Bl>ock, B<A>lternatively B<St>atement". Several constructs in Perl 6
+"B<Bl>ock, B<A>lternatively B<St>atement". Several constructs in Raku
 expect either a single L</statement>, or a L</block>. Thus, a blast:
 
     try { dangerous(); functions() };
@@ -309,12 +309,12 @@ See L</kebab case>, L</snake case>.
 
 =head2 Camelia
 
-The butterfly-like logo of Perl 6 as can be observed at L<http://perl6.org>.
+The butterfly-like logo of Raku as can be observed at L<http://perl6.org>.
 
 =head2 camelia
 
 The L</bot> on #perl6 channel that will evaluate code for you in various versions of
-Perl 5, Perl 6 and L</NQP>.
+Perl, Raku and L</NQP>.
 
 =head2 capture
 
@@ -356,12 +356,12 @@ A regex definition for one of the term kinds :
 
 =head2 character
 
-A L</string> is a sequence of characters.  Like in Perl 5, there is no
-character type in Perl 6 so when someone says a I<character> about a
+A L</string> is a sequence of characters.  Like in Perl, there is no
+character type in Raku so when someone says a I<character> about a
 L</value>, he means a string with one character. In L</Unicode> a
 character is called a L</grapheme> and may be composed of many L</codepoints>.
 But a string represented in the L</NFG> normalization form proper to
-Perl 6 has a codepoint per character. That leads to O(1) performance
+Raku has a codepoint per character. That leads to O(1) performance
 for many string operations. Depending on the level of abstraction, the
 length of a given string differs. The abstractions are bytes, codepoints and
 graphemes and the relevant methods are respectively L<.bytes>, L<.codes>,
@@ -375,7 +375,7 @@ Or a concurrent queue.
 
 =head2 christmas
 
-Release date for a Perl 6 implementation. It was a recurring joke because
+Release date for a Raku implementation. It was a recurring joke because
 the year was not specified. But at FOSDEM 2015, TimToady announced that the
 target date will be Christmas 2015.
 
@@ -439,7 +439,7 @@ Common Language Runtime, as used by Niecza/mono/.NET.
 
 Parts of a program intended for user consumption that are not used to
 generate code.  Beside the C<#> that starts a comment ending with the
-current line, Perl 6 supports many syntactic forms for different kinds of
+current line, Raku supports many syntactic forms for different kinds of
 comments.  Like inline comments that can be used as L</whitespace>, or
 comments that appear after a name declaration that are included in the
 L</pod> documentation.
@@ -453,8 +453,8 @@ once.  It involves the L</serialization> of code and data.
 
 =head2 compiler
 
-In a L</dynamic language> like Perl 6, the compiler is also referred to as
-L</interpreter>.  In simpler dynamic languages like Perl 5, the interpreter
+In a L</dynamic language> like Raku, the compiler is also referred to as
+L</interpreter>.  In simpler dynamic languages like Perl, the interpreter
 does not go through conceptual phases similar to the one for a compiler of
 non-dynamic language, the term compiler is rarely used.
 
@@ -493,7 +493,7 @@ Property of simultaneous computations sharing resources. It necessitates
 some form of collaboration to guaranty the consistency of the said
 resources. Computations are materialized by L</process>es or
 L</thread>s. Collaboration involves synchronization primitives
-likes mutexes, locks, semaphores.  Perl 6 provides high level
+likes mutexes, locks, semaphores.  Raku provides high level
 abstractions like L</feed>s, L</junction>s, L</hyperoperator>s,
 L</promise>s, L</channels> so that the programmer is usually spared
 the explicit use of threads and the endless problems they involve.
@@ -522,7 +522,7 @@ Context is also information that can affect parsing
 
 A L</variable> with a C<*> L</twigil>.  Used to set up contextual
 information that can be shadowed by calls deeper in the L</call
-stack>.  Heavily used in the Perl 6 compiler because Perl 6 is a very
+stack>.  Heavily used in the Raku compiler because Raku is a very
 contextual language, so gathered information affects the parsing. See
 L</keyword> for an example.
 
@@ -554,12 +554,12 @@ L</pair>s.
 =head2 CORE::
 
 A L</pseudo-scope> to access L</symbol>s of the outermost lexical L</scope>,
-definition of standard Perl.
+definition of standard Raku.
 
 =head2 CPAN
 
 Comprehensive Perl Archive Network.  A content delivery system for Perl
-distributions.
+and Raku distributions.
 
 =head2 credentials
 
@@ -587,7 +587,7 @@ used to give L</karma> to those who pushed the changes to the project.
 
 =head2 DarkPAN
 
-Perl code in production use at companies that has never been uploaded to
+Perl and Raku code in production use at companies that has never been uploaded to
 CPAN.  As in "how will this change affect the DarkPAN", which can't be
 answered because you generally don't have access to that code.
 
@@ -612,7 +612,7 @@ and inspecting variables.
 =head2 declarator
 
 a L</keyword> that introduces a L</symbol> and defines its L</scope> and
-L</extent>.  Perl 6 declarators are L</has>, L</my>, L</state>, L</our>,
+L</extent>.  Raku declarators are L</has>, L</my>, L</state>, L</our>,
 respectively for L<object variable|/object> , L<lexical variable|/lexical>,
 <stateful variable|/stateful> and L<package variable|/package variable>.  Also
 the L</twigil> C</*> in the name of a package or lexical variable sets its
@@ -713,8 +713,8 @@ One of the opposites of L</lazy>.
 
 =head2 ecosystem
 
-The L<ecosystem|https://github.com/perl6/ecosystem> is a repository of Perl
-6 modules installable by L</Panda>. L</Rakudo *> releases include a tested
+The L<ecosystem|https://github.com/perl6/ecosystem> is a repository of Raku
+modules installable by L</Panda>. L</Rakudo *> releases include a tested
 subset of the ecosystem.
 
 =head2 edsel
@@ -733,8 +733,8 @@ See the L<relevant Wikipedia entry|https://en.wikipedia.org/wiki/Failure#Interne
 
 =head2 EVAL
 
-A Perl 6 command that takes a string as an argument and executes its content
-as Perl 6 code.
+A Raku command that takes a string as an argument and executes its content
+as Raku code.
 
 =head2 exception
 
@@ -779,9 +779,9 @@ L</dispatcher> have failed.
 
 =head2 fat comma
 
-Contrary to Perl 5, C<< => >>, the fat comma does not simply separate two
+Contrary to Perl, C<< => >>, the fat comma does not simply separate two
 values but makes a L</Pair> out of them. The left value can be a L</bare
-string>. This is the only place where Perl 6 accepts a bare string. Example:
+string>. This is the only place where Raku accepts a bare string. Example:
 
       foo => bar
 
@@ -799,7 +799,7 @@ cross, zip, hyperify or assignify fiddly operators.
 =head2 FIFO
 
 L<First In First Out|https://en.wikipedia.org/wiki/FIFO>, a fairly common
-data structure in programming languages.  In Perl 6 an array behaves as such
+data structure in programming languages.  In Raku an array behaves as such
 when used as a L</queue>.  See also L</LIFO>.
 
 =head2 flap
@@ -837,7 +837,7 @@ Short for L</functional programming>
 
 =head2 freenode
 
-An L</IRC> server that hosts L</channel>s related to Perl 6 projects accessible
+An L</IRC> server that hosts L</channel>s related to Raku projects accessible
 through an IRC client at C<irc.freenode.org>.
 
 =head2 FSVO
@@ -850,7 +850,7 @@ Fixed That For You.
 
 =head2 fudge
 
-Way to temporarily mark tests in the L</spectest> for a specific Perl 6
+Way to temporarily mark tests in the L</spectest> for a specific Raku
 version as I<todo> (so that a failure of the test will be marked ok, and a
 pass will be marked as an exception), or as I<skip> if they cause a
 L</compile time> or L</runtime> exception.
@@ -858,7 +858,7 @@ L</compile time> or L</runtime> exception.
 =head2 functional programming
 
 A programming style that mostly or exclusively relies on functions, L</pure>
-or not.  Perl 6 supports functional programming but does not force it on
+or not.  Raku supports functional programming but does not force it on
 you.
 
 =head1 G
@@ -881,7 +881,7 @@ gensyms:
           (MULTIPLE-VALUE-BIND (#:G850) 1 (COMMON-LISP::%PUT #:G847
             #:G848 #:G850)))
 
-Current consensus is that we won't need gensyms for Perl 6 macros, because
+Current consensus is that we won't need gensyms for Raku macros, because
 we'll have Qtree nodes which, being objects, come pre-equipped with a
 "handle": their object identity.
 
@@ -901,7 +901,7 @@ L</IRC>. See L<https://gist.github.com> for the last usage.
 
 =head2 git
 
-The distributed source revision system used by many, if not all Perl 6
+The distributed source revision system used by many, if not all Raku
 projects, generally hosted on L</github>. A good
 L<glossary|https://www.kernel.org/pub/software/scm/git/docs/gitglossary.html>
 about git.  A good L<reference|http://git-scm.com/book>.
@@ -918,7 +918,7 @@ hosted on github.
 
 =head2 given
 
-Keyword for the Perl 6 switch L</statement>.
+Keyword for the Raku switch L</statement>.
 
 =head2 GLOBAL::
 
@@ -963,7 +963,7 @@ the entire jungle." says Joe Armstrong, Erlang creator, complaining of
 traditional L</OO> inheritance based environment inflexibility.  In non
 L</dynamic language>s, you can't dynamically add L</attribute>s/L</method>s
 for an L</object>/L</class> so you end up shoving everything you may ever
-need in a deep class hierarchy.  In Perl 6, the gorilla/banana problem is
+need in a deep class hierarchy.  In Raku, the gorilla/banana problem is
 solved with L</role>s that group methods or attributes. A role can be
 dynamically added to a class or an object.
 
@@ -972,13 +972,13 @@ dynamically added to a class or an object.
 According to wikipedia I<Gradual typing is a type system in which
 variables may be typed either at compile-time (which is L</static typing>)
 or at L</runtime> (which is L</dynamic typing>)>.
-Perl 6 supports gradual typing.
+Raku supports gradual typing.
 
 
 =head2 grammar
 
-A feature of Perl 6 that uses L</regex>es to implement a grammar for parsing
-text. Perl 6 implementations use grammars themselves to parse the language.
+A feature of Raku that uses L</regex>es to implement a grammar for parsing
+text. Raku implementations use grammars themselves to parse the language.
 The results of parsing with a grammar can be further passed on to
 L</actions>.  A grammar is composed of methods introduced by one of the
 three keywords C<rule>, C<L</token>>, C<regex>. There is L</backtrack>ing
@@ -986,7 +986,7 @@ only in C<regex> and C<rule> implies L</whitespace>s between subrules.
 
 Parsing is done conceptually in two phases, L<lexing> and L<syntax
 analysis>.  Lexing breaks the input string in tokens that are the
-input of L<syntax analysis|/Syntax analysis>. In Perl 6, things are
+input of L<syntax analysis|/Syntax analysis>. In Raku, things are
 not so clear cut and both phases are defined in the L</grammar>.
 
 
@@ -1020,12 +1020,12 @@ by the L</GC>. See L<Memory management|https://en.wikipedia.org/wiki/Memory_mana
 =head2 High Level Language
 
 A high level language provides abstractions that decouples it from specific
-operating systems and processors. Perl 6 is such a language and provides
+operating systems and processors. Raku is such a language and provides
 some interoperability with other HLLs when they are compiled with the rakudo
 toolkit.  Some of these abstractions like arrays, associative tables,
 integers, floats, strings and objects are common to many languages but
 specific semantic and underlying type L</representation>s may differ.  Also,
-a given language may provide many flavors of them.  Perl 6 provides common
+a given language may provide many flavors of them.  Raku provides common
 L</concrete syntax> to access them.  C<MVMHLLConfig> is the L</MoarVM> C
 level structure that hooks to the underlying language specific
 representations.  The L</metamodel> allows one to express specific semantics
@@ -1062,7 +1062,7 @@ L<Huffman coding|http://en.wikipedia.org/wiki/Huffman_coding> is a
 compression algorithm that encodes common symbols with a short code. By
 analogy, we call huffmanization alternative and shorter syntax for common
 syntax constructs. The cost of huffmanization is the cost of learning
-additional syntax.  In Perl 6, L</composer>s are a form of huffmanization.
+additional syntax.  In Raku, L</composer>s are a form of huffmanization.
 
 =head2 hyper
 
@@ -1173,7 +1173,7 @@ See L</Intermediate Representation>
 
 =head2 IRC
 
-Internet Relay Chat.  Perl 6 developers and users usually hang out on the
+Internet Relay Chat.  Raku developers and users usually hang out on the
 L</#perl6> L</channel> on L</freenode>. See also
 L<http://perl6.org/community/irc>.
 
@@ -1233,7 +1233,7 @@ L<http://doc.perl6.org/type/Junction>.
 =head2 JVM
 
 Java Virtual Machine. The virtual machine for the Java programming language.
-Now many programming languages including Perl 6 have L</compiler>s targeting
+Now many programming languages including Raku have L</compiler>s targeting
 the JVM.
 
 =head1 K
@@ -1241,14 +1241,14 @@ the JVM.
 =head2 karma
 
 A measure of appreciation on L</IRC>. Karma is set by "incrementing" a pseudo:
-"jnthn++ # moar commit". It is purely notional on L</#perl6> and other Perl 6 related channels because L</dalek>
+"jnthn++ # moar commit". It is purely notional on L</#perl6> and other Raku related channels because L</dalek>
 does not track karma anymore.
 
 =head2 kebab case
 
 A naming convention where a word boundaries in a multiple word identifier is
 indicated with a dash (-) character.  For example, "is-deeply".  Popular in Lisps
-and Perl 6.
+and Raku.
 
 See L</camel case>, L</snake case>.
 
@@ -1256,10 +1256,10 @@ See L</camel case>, L</snake case>.
 
 An alphabetical string that has a predefined meaning in the language
 source code.  In most languages keywords are reserved, that is they
-cannot be used as L</symbol>. Not in Perl 6, the compiler knows by
+cannot be used as L</symbol>. Not in Raku, the compiler knows by
 context if an alphabetical string is a keyword, a L</function> name
 used for a call or a sigiless L</parameter>. This will allow to add
-new keywords to Perl 6 in the future without breaking existing
+new keywords to Raku in the future without breaking existing
 programs.
 
 =head2 KISS
@@ -1284,7 +1284,7 @@ The property of a list not to evaluate elements until they are needed.
 
 According to L</WP> "lazy evaluation, or call-by-need is an evaluation
 strategy which delays the evaluation of an expression until its value is
-needed (non-strict evaluation)".  In Perl 6, strings and lists can be lazy
+needed (non-strict evaluation)".  In Raku, strings and lists can be lazy
 but other values are not.  That is, their content is evaluated when needed
 so they can be potentially infinite. As of January 2015, lazy strings are
 not supported. They may even not make the cut for the 6.0 specification.
@@ -1330,7 +1330,7 @@ non-dynamic language like C results in a library.
 =head2 LIFO
 
 L<Last In First Out|https://en.wikipedia.org/wiki/LIFO_(computing)>, a
-fairly common data structure in computer science.  In Perl 6 arrays behave
+fairly common data structure in computer science.  In Raku arrays behave
 as such when used as a L</stack>.  See also L</FIFO>.
 
 =head2 line noise
@@ -1371,7 +1371,7 @@ Let Me Google That For You.  L<http://lmgtfy.com/>
 A local variable, in L</QAST>, is local to a L</frame>. A L</HLL> lexical variable
 may end up as local in QAST if it is not captured by outer L</scope>. When the QAST is compiled and L</JIT>ed
 to an executable, the value accessible thru the local, modulo some L</SSA> magic, is accessible in a processor
-register. There is no relationship with the local scope in Perl 5.
+register. There is no relationship with the local scope in Perl.
 
 =head2 LoL
 
@@ -1379,9 +1379,9 @@ B<L>ist B<o>f B<L>ist
 
 =head2 longname
 
-Because Perl 6 has the capability of L</multiple dispatch>, several methods
+Because Raku has the capability of L</multiple dispatch>, several methods
 or subroutines may have the same name but different parameters (different in
-number or in type). Perl decides which routine to call by looking at the
+number or in type). Raku decides which routine to call by looking at the
 B<longname> which consists of the name of the routine and the type signature
 of its invocant arguments. See also L</shortname>, L</multi-method>, and
 L</multi-sub>.
@@ -1406,8 +1406,8 @@ with L</bytecode>.
 =head2 magic variable
 
 L<Variable|/variable> that has a behavior of its own and that is denoted by
-a sigiless name with a non alphanumeric character.  Unlike Perl 5 that has a
-profusion of magic variables, Perl 6 includes only the magic variables
+a sigiless name with a non alphanumeric character.  Unlike Perl that has a
+profusion of magic variables, Raku includes only the magic variables
 L</$_>, L</"$/">, L</$¢> and L<$!>. They are L</block> L</scope>d and are implicitly
 defined at the beginning of each block.
 
@@ -1415,11 +1415,11 @@ defined at the beginning of each block.
 
 When present, a L</multi>L<sub> that is the entry point of a L</program> L</runtime>.
 The code in L</phaser>s intended to run at compile time are executed before MAIN.
-Like in Perl 5, a MAIN sub is not necessary.
+Like in Perl, a MAIN sub is not necessary.
 
 =head2 MAST
 
-L</MoarVM> specific L</AST>. When the Perl 6 L</backend> is MoarVM, L</QAST>, the AST obtained from early stages of
+L</MoarVM> specific L</AST>. When the Raku L</backend> is MoarVM, L</QAST>, the AST obtained from early stages of
 L</source code> L</compilation> is converted into MAST. The MAST is then used to generate MoarVM
 L</bytecode>.
 
@@ -1446,14 +1446,14 @@ See also L</parse>.
 =head2 META.info
 
 A L</JSON> file that lies in the root of a L</repository> for a project written
-in Perl 6. It describes a project and list its dependencies.
+in Raku. It describes a project and list its dependencies.
 Documented in L<spec.pod|https://github.com/perl6/ecosystem/blob/master/spec.pod>.
 
 =head2 metamodel
 
 The metamodel describes some L<OO> behaviors, like where to find a
 L</method>.  This permits implementation of different OO behaviors in the
-same L</VM>.  The Perl 6 implementation of the metamodel is called
+same L</VM>.  The Raku implementation of the metamodel is called
 L</6model>.  The metamodel should not be confused with the
 L</representation>.
 
@@ -1543,9 +1543,9 @@ A L</pseudo-scope> to access L</symbol>s  in the current L</lexical scope>
 
 =head2 native
 
-Something that does not pertain the Perl interpreter proper but
+Something that does not pertain the Raku interpreter proper but
 to the L</backend> or the underlying system.
-See also: L</pure Perl>
+See also: L</pure Raku>
 
 =head2 Native Call
 
@@ -1581,7 +1581,7 @@ L<https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton>.
 
 =head2 NFG
 
-Proposed L</Unicode Normalization Form> for Perl 6, in which composed
+Proposed L</Unicode Normalization Form> for Raku, in which composed
 characters always get their own codepoint. If a codepoint doesn't exist for
 that composed character, one is assigned dynamically.
 
@@ -1589,7 +1589,7 @@ Documentation for this can hypothetically be found in L<S15>.
 
 =head2 Niecza
 
-An implementation of Perl 6 targeting the .NET platform.
+An implementation of Raku targeting the .NET platform.
 
 =head2 Nil
 
@@ -1620,7 +1620,7 @@ Null Pointer Exception.
 
 =head2 NQP
 
-Short for B<N>ot B<Q>uite B<P>erl, a subset of Perl 6 suitable for tasks
+Short for B<N>ot B<Q>uite B<P>erl, a subset of Raku suitable for tasks
 such as implementing L</Rakudo>. Targets L</Parrot>, the L</JVM> and
 L</MoarVM>.
 
@@ -1641,7 +1641,7 @@ Sometimes combined with L</golfing>.
 
 For non L</dynamic language>s, from a L</compilation unit>, the L</compiler>
 generates object code or library. A latter phase links object code to
-generate an executable.  For dynamic languages like Perl 6, the equivalent
+generate an executable.  For dynamic languages like Raku, the equivalent
 of object code is the L</bytecode> and the linking phase is more complex and
 involves the deL</serialization> of information.
 
@@ -1688,7 +1688,7 @@ syntax, what would be the L</argument>s of the function are named operands
 instead. Operators are classified into
 L<categories|http://design.perl6.org/S02.html#Grammatical_Categories> of
 categories.  A category has a precedence, an arity, and can be L</fiddly>,
-L</iffy>, L</diffy>.  Perl 6 is very creative as to what is an operator, so
+L</iffy>, L</diffy>.  Raku is very creative as to what is an operator, so
 there are many categories.  Operators are made of many tokens, possibly with
 a subexpression.  For example, C<@a[0]> belongs to the postcircumfix
 category, is broken into the operand C<@a> and the postcircumfix operator
@@ -1752,7 +1752,7 @@ Compare with the L</adverbial pair> notation.
 
 =head2 Panda
 
-A Perl 6 L</package manager> designed to make it easier to download, compile and install
+A Raku L</package manager> designed to make it easier to download, compile and install
 L</module>s according to the transitive dependencies specified in the
 C<META.info> metadata files of said modules.  Unlike other L</package
 manager>s, panda supports many L</VM>s, namely the three VMs supported by
@@ -1786,7 +1786,7 @@ A L</pseudo-scope> to access lexical L</symbol>s in the unit's L<DSL>
 
 =head2 Parrot
 
-A virtual machine designed to run Perl 6 and other L</dynamic language>s.
+A virtual machine designed to run Raku and other L</dynamic language>s.
 Mostly historic.
 
 =head2 parser
@@ -1819,7 +1819,7 @@ Short for "problem".  As in "that's not the pb".
 =head2 PBP
 
 "Perl Best Practices".  The book by Damian Conway outlining best practices
-when programming Perl 5.
+when programming Perl.
 
 =head2 PDD
 
@@ -1836,7 +1836,7 @@ Parsing Expression Grammar. See L</grammar>.
 
 =head2 Perlito
 
-A L</compiler> project that has frontends for Perl 5 and Perl 6, as well as
+A L</compiler> project that has frontends for Perl and Raku, as well as
 multiple backends.
 
 =head2 phaser
@@ -1849,7 +1849,7 @@ run (C<END>).
 =head2 PIO
 
 An implementation specific internal object for doing I/O.  Originally a
-Parrot I/O object, now a Perl I/O object.
+Parrot I/O object, now a Raku I/O object.
 
 =head2 PIR
 
@@ -1861,12 +1861,12 @@ Parrot Magic Cookie.
 
 =head2 pod
 
-B<P>lain B<O>l' B<D>ocumentation, a documentation format understood by Perl
-6. See L<S26|http://design.perl6.org/S26.html> for details.
+B<P>lain B<O>l' B<D>ocumentation, a documentation format understood by Raku.
+See L<S26|http://design.perl6.org/S26.html> for details.
 
 =head2 pod6
 
-Used to specify Perl 6's version of L</pod>, as opposed to Perl 5's.
+Used to specify Raku's version of L</pod>, as opposed to Perl's.
 
 =head2 pointy block
 
@@ -1902,13 +1902,13 @@ An operator that comes after the term it belongs to.
 
 =head2 PPI
 
-Perl 5 module for parsing, analyzing and manipulating Perl 5 source code.
+Perl module for parsing, analyzing and manipulating Perl source code.
 L<https://metacpan.org/pod/PPI>.
 
 =head2 pragma
 
 A pragma is a module which influences some aspect of the compile time or
-run time behaviour of Perl.
+run time behaviour of Raku.
 
 =head2 precedence
 
@@ -1961,7 +1961,7 @@ L</symbol>s.
 
 A project is a L</version>ed L</repository>.
 It typically contains a C<bin> folder and a C<lib> and C<t> hierarchy.
-They respectively contain executable scripts, Perl 6 libraries and tests.
+They respectively contain executable scripts, Raku libraries and tests.
 The list of projects is maintained in the L<ecosystem> repository.
 The L</META.info> file drives the compilation and installation of the
 project by the L</project management software>.
@@ -1994,7 +1994,7 @@ Short for L</pull request>.
 
 =head2 prove
 
-Perl 5 script to run tests through a L</TAP> harness.
+Perl script to run tests through a L</TAP> harness.
 See L<prove|http://perldoc.perl.org/prove.html>.
 
 =head2 PSA
@@ -2010,8 +2010,8 @@ and made changes to it that they wish to have in the main project.
 
 =head2 pugs
 
-A Perl 6 implementation in Haskell, led by the efforts of Audrey Tang.  The
-first truly usable Perl 6 implementation, it was actively developed 2005
+A Raku implementation in Haskell, led by the efforts of Audrey Tang.  The
+first truly usable Raku implementation, it was actively developed 2005
 through 2007.
 
 =head2 punctuational variable
@@ -2022,7 +2022,7 @@ Another name for L</magic variable>.
 
 When a role is used as a class, punning is the implicit operation that
 converts the role to the class using the metaclass compose method.  In
-a wider, non-Perl 6 context, it can refer to any implicit conversion.
+a wider, non-Raku context, it can refer to any implicit conversion.
 
 =head2 pure
 
@@ -2031,18 +2031,18 @@ and the value it gives is depends only of its arguments so it is
 L<referentially transparent|/referential transparent> giving the opportunity
 of optimizations.
 
-=head2 pure perl
+=head2 pure raku
 
 Use to qualify Some source code, or L</project> that does not depend
-on non Perl resources like a L</shared library> generated from C code.
+on non Raku resources like a L</shared library> generated from C code.
 
 =head2 p5
 
-Short for Perl 5, the (older brother|parent) of Perl 6.
+Short for Perl, from which Raku originated.
 
 =head2 p6
 
-Short for Perl 6, the (spunky little sister|child) of Perl 5.
+Short for Raku.
 
 =head2 P6W
 
@@ -2065,7 +2065,7 @@ result data is returned.
 
 =head2 Rakudo
 
-An implementation of Perl 6 originally targeting L</Parrot>, it now targets
+An implementation of Raku originally targeting L</Parrot>, it now targets
 Parrot, the L</JVM>, and L</MoarVM> through L</NQP>.
 
 =head2 Rakudo *
@@ -2106,7 +2106,7 @@ kinds of information.
 
 =head2 regexp
 
-An alternative abbreviation of L</regex> that usually occurs in non-Perl 6
+An alternative abbreviation of L</regex> that usually occurs in non-Raku
 contexts.
 
 =head2 reification
@@ -2130,9 +2130,8 @@ a line is finished.
 A repository contains the information pertaining to a software or its
 L</module>s.  That is the source code, its history and ancillary information
 like a wiki, a bug tracking system, a static web site, depending on the
-hosting service containing the repository.  Usually Perl 6 related
-information is stored in L</github> repositories.  The official list of Perl
-6 modules is the L</ecosystem> which is also stored in a repository.  When
+hosting service containing the repository.  Usually Raku related
+information is stored in L</github> repositories.  The official list of Raku modules is the L</ecosystem> which is also stored in a repository.  When
 installing a module, the L</panda> L</package manager> uses the ecosystem to
 fetch the appropriate repositories for transitive dependencies.
 
@@ -2157,9 +2156,9 @@ a branch.  It is different from a reset that throws away changes.
 
 =head2 roast
 
-The Perl 6 L<specification tests|/spectest>, which live here:
+The Raku L<specification tests|/spectest>, which live here:
 L<https://github.com/perl6/roast/>.  Originally developed for L</pugs>, it
-now serves all Perl 6 implementations.  Why roast? It's the B<r>epository
+now serves all Raku implementations.  Why roast? It's the B<r>epository
 B<o>f B<a>ll B<s>pec B<t>ests.
 
 =head2 role
@@ -2198,7 +2197,7 @@ L<here|https://github.com/MoarVM/MoarVM/blob/master/src/gc/roots.h>.
 
 L<Rosalind|http://rosalind.info/> is a platform for learning bioinformatics
 and programming through problem solving.  Some of the problems are solved
-through elegant Perl 6 code snippets.
+through elegant Raku code snippets.
 
 =head2 Rosetta Code
 
@@ -2294,7 +2293,7 @@ arguments.  See L</longname>.
 
 =head2 sigil
 
-In Perl, the sigil is the first character of a variable name.  It must be
+In Raku, the sigil is the first character of a variable name.  It must be
 either C<$>, C<@>, C<%>, or C<&> respectively for a scalar, array, hash, or
 code variable.  See also L</twigil> and L</role>.  Also sigilled variables
 allow short conventions for L<variable interpolation> in a double quoted
@@ -2316,13 +2315,13 @@ L<Context|/context> of an expression whose value is ignored.  Often called
 =head2 sixplanet
 
 L<sixplanet|http://planeteria.org/perl6/> is a collation of blogs related to
-Perl 6.  If planeteria.org is down, a replacement can be found on
+Raku.  If planeteria.org is down, a replacement can be found on
 L<http://pl6anet.org/>.
 
 =head2 slang
 
-Short for sublanguage. A slang is a L</grammar> derived from the Perl 6
-grammar, and its associated L</actions>.  Alternatively the Perl 6 syntax
+Short for sublanguage. A slang is a L</grammar> derived from the Raku
+grammar, and its associated L</actions>.  Alternatively the Raku syntax
 can be seen as the combination of many slangs (the regex slang, the
 quotation slang...) Defining a slang has a cost because it usually involves
 generating new L</NFA> tables; except for the space taken by the said
@@ -2335,7 +2334,7 @@ Domain Specific Languages (DSLs).
 
 A naming convention where a word boundaries in a multiple word identifier is
 indicated with an underscore (_) character.  For example, "is_deeply".  Popular
-in Perl 5, Python, and other scripting languages.
+in Perl, Python, and other scripting languages.
 
 See L</camel case>, L</kebab case>.
 
@@ -2363,8 +2362,8 @@ Textual form of a L</program>.
 =head2 spectest
 
 Alternative name for L</roast> after the name of its target name in
-L</rakudo compiler>.  A program that passes the Perl 6 L</test suite>
-is a valid Perl 6 L</compiler>.
+L</rakudo compiler>.  A program that passes the Raku L</test suite>
+is a valid Raku L</compiler>.
 L<Link|https://github.com/perl6/roast> to the L</github>
 L</repository> that contains the said test suite.
 
@@ -2448,7 +2447,7 @@ Name of the string type.
 A sequence of characters.  See L</characters> for the definition of
 string length according to the different abstractions underlying a
 L</Unicode> string.  There is some speculation of string being
-L</lazy> in some future Perl 6 version.
+L</lazy> in some future Raku version.
 
 =head2 sub
 
@@ -2486,7 +2485,7 @@ Not to be confused with L<Closure parameters|/"Closure Parameter">.
 =head2 symbol
 
 Fancy alternative way to denote a name. Generally used in the context of
-L</module>s linking, be it in the L</OS> level, or at the Perl 6 L</VM> level
+L</module>s linking, be it in the L</OS> level, or at the Raku L</VM> level
 for modules generated from languages targeting these VMs.  The set of
 L</import>ed or exported symbols is called the symbol table.
 
@@ -2494,7 +2493,7 @@ L</import>ed or exported symbols is called the symbol table.
 
 =head2 Synopsis
 
-The current human-readable description of the Perl 6 language.  Still in
+The current human-readable description of the Raku language.  Still in
 development.  Much more a community effort than the L</Apocalypse>s and
 L<Exegeses|/Exegesis> were. The current state of the language is reflected
 by L<roast>, its L</test suite>, not the synopses where speculative material
@@ -2536,7 +2535,7 @@ L<tail call> optimization.
 
 =head2 test suite
 
-The Perl 6 test suite is L</roast>
+The Raku test suite is L</roast>
 
 =head2 ASCII operator
 
@@ -2563,7 +2562,7 @@ code to L</DWIM> or from an interrupted thought process.
 
 An execution unit more lightweight than a L</process>.  Threads allow
 parallelization of code for concurrent performance but it is tricky to
-modify information shared by the different threads of a process.  Perl 6
+modify information shared by the different threads of a process.  Raku
 provides many primitives that create threads when needed so direct thread
 use is possible but should be done only when necessary.
 
@@ -2592,7 +2591,7 @@ Examples for thunks:
 
 =head2 TimToady
 
-L</IRC> screen name for Larry Wall, creator of Perl. The name comes from the
+L</IRC> screen name for Larry Wall, creator of Perl and Raku. The name comes from the
 pronunciation of L</TMTOWTDI> as a word.
 
 =head2 TIMTOWTDI
@@ -2611,7 +2610,7 @@ Too Much Information.
 
 =head2 TMTOWTDI
 
-"There's More Than One Way To Do It", the Perl motto.
+"There's More Than One Way To Do It", the motto of Perl and Raku.
 
 =head2 token
 
@@ -2696,10 +2695,10 @@ L<categories|/category> L</prefix>, L</postfix> and L</circumfix> are unary.
 
 Unicode is a standard defining the encodings, representation and handling of
 text in most writing systems.  This standard includes a useful L<Unicode
-glossary|http://www.unicode.org/glossary/>.  For Perl 6 handling of Unicode,
+glossary|http://www.unicode.org/glossary/>.  For Raku handling of Unicode,
 see the
 L<documentation|https://raw.githubusercontent.com/perl6/specs/master/S15-unicode.pod>.
-See also L</NFG> for an encoding specific to Perl 6.
+See also L</NFG> for an encoding specific to Raku.
 
 =head2 Unicode Character Database
 
@@ -2711,7 +2710,7 @@ L<also|http://www.unicode.org/ucd/>.
 =head2 Unicode Normalization Form
 
 See L</UAX> L<15|http://unicode.org/reports/tr15/>.
-Perl 6 defines an additional one : L</NFG>.
+Raku defines an additional one : L</NFG>.
 
 =head2 unit
 
@@ -2771,7 +2770,7 @@ is not visible.
 
 =head2 Virtual Machine
 
-A virtual machine is the Perl compiler entity that executes the
+A virtual machine is the Raku compiler entity that executes the
 L</bytecode>.  It can optimize the bytecode or generate L</machine code>
 L<Just in Time|/JIT>.  Such as L</Parrot>, L</JVM> and L</MoarVM>.
 
@@ -2782,14 +2781,13 @@ See L</Virtual Machine>.
 =head2 v5
 
 Stands for "Perl, version 5" and is used in code to indicate that the code
-is Perl 5:
+is Perl:
 
     use v5;
 
 =head2 v6
 
-Stands for "Perl, version 6" and is used in code to indicate that the code
-is written in Perl 6:
+Is used in code to indicate that the code is written in Raku:
 
     use v6;
 
@@ -2807,7 +2805,7 @@ of L</DWIM>.
 =head2 Weekly Changes
 
 Mostly weekly L<report|http://p6weekly.wordpress.com/> about changes in the
-Perl 6 World.  See also: L</sixplanet>.
+Raku World.  See also: L</sixplanet>.
 
 =head2 wfm
 
@@ -2821,7 +2819,7 @@ L<http://doc.perl6.org/type/Whatever>.
 
 The negative space between syntactic constructs within a language.
 Typically consists of spaces, tabs, newlines, form feeds, and other
-"invisible" characters. For the purposes of parsing Perl 6, L</comment>s are
+"invisible" characters. For the purposes of parsing Raku, L</comment>s are
 also considered whitespace. See also L</unspace>.
 
 =head2 WIP
@@ -2850,9 +2848,8 @@ channel that was intended for another channel, or for a private message.
 
 =head2 XS
 
-Perl 5's mechanism for bridging the gap between pure-Perl code and compiled
-system libraries. Writing XS modules involves C code and some knowledge of Perl
-5's inner workings, and installing them needs a compiler. The Perl 6 equivalent
+Perl's mechanism for bridging the gap between pure-Perl code and compiled
+system libraries. Writing XS modules involves C code and some knowledge of Perl's inner workings, and installing them needs a compiler. The Raku equivalent
 is C<NativeCall>; see L<S21|S21: Calling foreign code>.
 
 =head2 XY Problem
@@ -2901,7 +2898,7 @@ Oh, um... L</Whatever>.
 
 =head2 #perl6
 
-L</IRC> L</channel> on L</freenode> that hosts discussions related to Perl 6.
+L</IRC> L</channel> on L</freenode> that hosts discussions related to Raku.
 Archived on L<http://irclog.perlgeek.de/perl6/>.
 
 =head2 .
@@ -2932,7 +2929,7 @@ See L</empty list>.
 
 =head2 @_
 
-The Perl 5 style argument list.  Something you should stop using, and use
+The Perl style argument list.  Something you should stop using, and use
 subroutine signatures instead.
 
 =head2 $_

--- a/html/index.html
+++ b/html/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta charset="UTF-8" />
-<title>Perl 6 Design Documents</title>
+<title>Raku Design Documents</title>
 <link rel="stylesheet" href="style.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -43,7 +43,7 @@
   <a href="https://github.com/perl6/mu/blob/master/misc/camelia.txt">
     <img src="//perl6.org/camelia-logo.png" alt="camelia perl bug logo">
   </a>
-  <h1>Perl 6 Design Documents</h1>
+  <h1>Raku Design Documents</h1>
 
   <form method="get" action="https://encrypted.google.com/search">
     <div>
@@ -58,9 +58,9 @@
 </header>
 
 <main>
-<p>The Synopsis documents are the design documents used to guide Perl 6 language, compiler, and test development.  As design documents, they're frequently subjected to the rigors of cross-examination through implementation and use in practice.  In other words, they may change slightly or radically, but the expectation is that they are ``very close`` to the final shape of Perl 6.</p>
+<p>The Synopsis documents are the design documents used to guide Raku language, compiler, and test development.  As design documents, they're frequently subjected to the rigors of cross-examination through implementation and use in practice.  In other words, they may change slightly or radically, but the expectation is that they are ``very close`` to the final shape of Raku.</p>
 
-<p>In the past the Synopses have often been referred to as "the formal Perl 6 specification" and "specs", but this usage is being deprecated in favor of treating tests from the "<a href='http://github.com/perl6/roast'>roast</a>" test suite as official specifications.  This is consistent with Synopsis 1, which says "Perl 6 is anything that passes the official test suite."
+<p>In the past the Synopses have often been referred to as "the formal Raku specification" and "specs", but this usage is being deprecated in favor of treating tests from the "<a href='http://github.com/perl6/roast'>roast</a>" test suite as official specifications.  This is consistent with Synopsis 1, which says "Raku" is anything that passes the official test suite."
 <a href="#" id="read-more" hidden>[Read more...]</a></p>
 
 <aside id="intro-text">
@@ -110,7 +110,7 @@ that they are historical documents and not kept up-to-date.</em></p>
     </tr>
     <tr>
         <td>3</td>
-        <th><a href="S03.html">Summary of Perl&nbsp;6 Operators</a></th>
+        <th><a href="S03.html">Summary of Raku Operators</a></th>
         <td><a href="https://raw.github.com/perl6/specs/master/S03-operators.pod">S03-operator.pod</a></td>
         <td><a href="http://dev.perl.org/perl6/doc/design/apo/A03.html">Apocalypse</a></td>
         <td><a href="http://dev.perl.org/perl6/doc/design/exe/E03.html">Exegesis</a></td>
@@ -251,7 +251,7 @@ that they are historical documents and not kept up-to-date.</em></p>
         <td><a href="https://raw.github.com/perl6/specs/master/S26-documentation.pod">S26-documentation.pod</a></td>
         <td colspan="2">(HTML rendering of S26 is known to be incomplete)</td>
     </tr>
-    <tr><td>27</td><td>Perl culture</td><td colspan="4">(Draft)</td></tr>
+    <tr><td>27</td><td>Raku culture</td><td colspan="4">(Draft)</td></tr>
     <tr>
         <td>28</td>
         <th><a href="S28.html">Special names</a></th>
@@ -368,15 +368,15 @@ that they are historical documents and not kept up-to-date.</em></p>
 </section>
 
 <section>
-<h2>Differences from Perl 5</h2>
+<h2>Differences from Perl</h2>
 
 <ul>
-    <li><a href="Differences.html">Differences Between Perl 5 and Perl 6</a></li>
+    <li><a href="Differences.html">Differences Between Perl and Raku</a></li>
 </ul>
 
 <p>
 The Differences document is stored in <code>docs/Perl6/Perl5/Differences.pod</code>
-in the <a href="https://github.com/perl6/mu/" title="Perl 6 mu repository on Github">mu repository</a>,
+in the <a href="https://github.com/perl6/mu/" title="Raku mu repository on Github">mu repository</a>,
 if you'd like to make updates to it. Your changes will automatically appear on the web server in less than one hour.
 </p>
 </section>
@@ -384,9 +384,8 @@ if you'd like to make updates to it. Your changes will automatically appear on t
 <section>
 <h2>Further reading</h2>
 
-<p>For further information on Perl 6, links to examples, tutorials etc. please
-visit <a href="https://perl6.org/">perl6.org, the official Perl 6
-homepage</a>.</p>
+<p>For further information on Raku, links to examples, tutorials etc. please
+visit <a href="https://raku.org/">raku.org, the official Raku homepage</a>.</p>
 </section>
 </main>
 
@@ -396,12 +395,12 @@ homepage</a>.</p>
 <p>The HTML version of Synopses contains code snippets from the official 
  test suite. In other words, the .t files from the test suite are 
 divided into pieces and inserted after corresponding paragraph of 
-the Synopses.  The job is done by the Perl 5 script util/smartlinks.pl
-living in the <a href="https://github.com/perl6/mu/" title="Perl 6 mu
+the Synopses.  The job is done by the Perl script util/smartlinks.pl
+living in the <a href="https://github.com/perl6/mu/" title="Raku mu
 repository on Github">mu repository</a>. It runs once every hour and is
 triggered by the file <code>util/update-design.perl6.org.sh</code> in the mu
-repository. It runs as user <code>design.perl6.org</code> on <a
-href="https://github.com/perl6/infrastructure-doc/blob/master/hosts/hack.p6c.org.pod">hack.p6c.org</a>
+repository. It runs as user <code>design.raku.org</code> on <a
+href="https://github.com/perl6/infrastructure-doc/blob/master/hosts/hack.raku.org.pod">hack.raku.org</a>
 and is copied to the web server via rsync.</p>
 </footer>
 

--- a/html/perl-with-historical-message.css
+++ b/html/perl-with-historical-message.css
@@ -9,7 +9,7 @@ body {
 }
 
 body:before {
-    content: "Note: these documents may be out of date. For Perl 6 documentation see docs.perl6.org; for specs, see the official test suite.";
+    content: "Note: these documents may be out of date. For Raku documentation see docs.perl6.org; for specs, see the official test suite.";
     text-align: center;
     background: #600;
     color: white;

--- a/html/style.css
+++ b/html/style.css
@@ -66,7 +66,7 @@ html {
 }
 
 html:before {
-    content: "Note: these documents may be out of date. For Perl 6 documentation see docs.perl6.org; for specs, see the official test suite.";
+    content: "Note: these documents may be out of date. For Raku documentation see docs.raku.org; for specs, see the official test suite.";
     text-align: center;
     background: #600;
     color: white;


### PR DESCRIPTION
This goes beyond just replacing "Perl 6" with "Raku", and "Perl 5" by "Perl".
Clearly, many of the oldest documents still assumed that Raku was going to be
another version of "Perl", hence the word "Perl" was often used without any
digit following it.  I have tried to deduce the meaning from the context and
either changed these to "Raku" (looking towards the future), or left them to
be "Perl" (when looking to the past).

I've also done this as Raku hopefully will get some more eyeballs looking at
it, and how it got designed / conceived.  Having a mix of "Perl", "Perl 5"
and "Perl 6" in there, will only cause more confusion.  Which we do *NOT*
want to have.

Errors may have been made in this editorial process.  So please do not assume
this is canon in any way!  If you think something is wrong, let us know or
even better, provide a Pull Request!

Thank you for reading this!