### PR TITLE
fix identifier in used context ( Synopsis 26 )

### DIFF
--- a/S26-documentation.pod
+++ b/S26-documentation.pod
@@ -2653,7 +2653,7 @@ For example:
     The use of A<PROGNAME> is subject to the terms and conditions
     laid out by A<VENDOR>, as specified at:
 
-        A<TERMS_URL>
+        A<TERMS_URLS>
 
 =end code
 


### PR DESCRIPTION
In example  used  `=alias TERMS_URLS` 
and corresponding identifier should be   `A<TERMS_URLS> `
